### PR TITLE
Fix TUI, transfer, and release safety

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,10 +180,53 @@ jobs:
           name: ${{ matrix.name }}
           path: dist/*
 
+  release-guard:
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag, package version, and main ancestry
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::error::Release tag must be an exact vX.Y.Z semantic version: $TAG"
+            exit 1
+          fi
+          TAG_VERSION="${BASH_REMATCH[1]}"
+
+          MANIFEST_VERSION=$(awk -F '"' '/^version = "/ { print $2; exit }' Cargo.toml)
+          LOCK_VERSION=$(
+            awk -F '"' \
+              '$0 == "name = \"pikpaktui\"" { getline; if ($0 ~ /^version = "/) { print $2; exit } }' \
+              Cargo.lock
+          )
+          if [[ -z "$MANIFEST_VERSION" || -z "$LOCK_VERSION" ]]; then
+            echo "::error::Could not read the pikpaktui version from Cargo.toml and Cargo.lock."
+            exit 1
+          fi
+          if [[ "$TAG_VERSION" != "$MANIFEST_VERSION" || "$TAG_VERSION" != "$LOCK_VERSION" ]]; then
+            echo "::error::Version mismatch: tag=$TAG_VERSION Cargo.toml=$MANIFEST_VERSION Cargo.lock=$LOCK_VERSION"
+            exit 1
+          fi
+
+          git fetch --quiet origin "+refs/heads/main:refs/remotes/origin/main"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "refs/remotes/origin/main"; then
+            echo "::error::Release commit $GITHUB_SHA is not part of origin/main."
+            exit 1
+          fi
+
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, release-guard]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -208,6 +251,7 @@ jobs:
             if ls *.exe 1>/dev/null 2>&1; then
               zip "../${name}.zip" pikpaktui.exe
             else
+              chmod +x pikpaktui
               tar czf "../${name}.tar.gz" pikpaktui
             fi
             cd ..
@@ -294,9 +338,8 @@ jobs:
   publish-crate:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    needs: test
+    needs: [release, release-guard]
     if: startsWith(github.ref, 'refs/tags/')
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -313,7 +356,7 @@ jobs:
   update-tap:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
-    needs: release
+    needs: [release, release-guard]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
@@ -331,18 +374,21 @@ jobs:
           VERSION=${{ steps.release.outputs.VERSION }}
           URL_ARM_MAC="https://github.com/Bengerthelorf/pikpaktui/releases/download/${VERSION}/pikpaktui-aarch64-macos.tar.gz"
           URL_INTEL_MAC="https://github.com/Bengerthelorf/pikpaktui/releases/download/${VERSION}/pikpaktui-x86_64-macos.tar.gz"
-          URL_LINUX="https://github.com/Bengerthelorf/pikpaktui/releases/download/${VERSION}/pikpaktui-x86_64-linux.tar.gz"
+          URL_ARM_LINUX="https://github.com/Bengerthelorf/pikpaktui/releases/download/${VERSION}/pikpaktui-aarch64-linux.tar.gz"
+          URL_INTEL_LINUX="https://github.com/Bengerthelorf/pikpaktui/releases/download/${VERSION}/pikpaktui-x86_64-linux.tar.gz"
 
           wget -q -O pikpaktui-aarch64-macos.tar.gz "$URL_ARM_MAC"
           wget -q -O pikpaktui-x86_64-macos.tar.gz "$URL_INTEL_MAC"
-          wget -q -O pikpaktui-x86_64-linux.tar.gz "$URL_LINUX"
+          wget -q -O pikpaktui-aarch64-linux.tar.gz "$URL_ARM_LINUX"
+          wget -q -O pikpaktui-x86_64-linux.tar.gz "$URL_INTEL_LINUX"
 
       - name: Calculate SHA256
         id: shasum
         run: |
           echo "SHA_ARM_MAC=$(sha256sum pikpaktui-aarch64-macos.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
           echo "SHA_INTEL_MAC=$(sha256sum pikpaktui-x86_64-macos.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "SHA_LINUX=$(sha256sum pikpaktui-x86_64-linux.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "SHA_ARM_LINUX=$(sha256sum pikpaktui-aarch64-linux.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "SHA_INTEL_LINUX=$(sha256sum pikpaktui-x86_64-linux.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
       - name: Checkout Tap Repository
         uses: actions/checkout@v4
@@ -371,8 +417,13 @@ jobs:
                 sha256 "${{ steps.shasum.outputs.SHA_INTEL_MAC }}"
               end
             elsif OS.linux?
-              url "https://github.com/Bengerthelorf/pikpaktui/releases/download/${{ steps.release.outputs.VERSION }}/pikpaktui-x86_64-linux.tar.gz"
-              sha256 "${{ steps.shasum.outputs.SHA_LINUX }}"
+              if Hardware::CPU.arm?
+                url "https://github.com/Bengerthelorf/pikpaktui/releases/download/${{ steps.release.outputs.VERSION }}/pikpaktui-aarch64-linux.tar.gz"
+                sha256 "${{ steps.shasum.outputs.SHA_ARM_LINUX }}"
+              else
+                url "https://github.com/Bengerthelorf/pikpaktui/releases/download/${{ steps.release.outputs.VERSION }}/pikpaktui-x86_64-linux.tar.gz"
+                sha256 "${{ steps.shasum.outputs.SHA_INTEL_LINUX }}"
+              end
             end
 
             def install

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 
 .DS_Store
 TODO.md
+
+# Machine-local assistant settings
+.claude/settings.local.json
+
+# Local VitePress dependencies and generated output
+docs/vitepress/node_modules/
+docs/vitepress/.vitepress/cache/
+docs/vitepress/.vitepress/dist/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pikpaktui"
 version = "0.0.57"
 edition = "2024"
+rust-version = "1.90"
 description = "A TUI and CLI client for PikPak cloud storage"
 license = "Apache-2.0"
 repository = "https://github.com/Bengerthelorf/pikpaktui"

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -277,7 +277,7 @@ pikpaktui download [options] -t <local_dir> <path...>
 |------|-------------|
 | `-o`, `--output <file>` | Custom output filename (single file only) |
 | `-t <local_dir>` | Batch mode — download multiple items into `<local_dir>` |
-| `-j`, `--jobs <n>` | Concurrent download threads (default: 1) |
+| `-j`, `--jobs <n>` | Concurrent files within recursive folder downloads (1–16; default: 1) |
 | `-n`, `--dry-run` | Preview without downloading |
 
 **Examples:**
@@ -287,12 +287,12 @@ pikpaktui download "/My Pack/file.txt"                  # to current dir
 pikpaktui download "/My Pack/file.txt" /tmp/file.txt    # to specific path
 pikpaktui download -o output.mp4 "/My Pack/video.mp4"   # custom name
 pikpaktui download "/My Pack/folder"                    # recursive folder
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4      # 4 concurrent, batch
+pikpaktui download -j 4 "/My Pack/folder"              # up to 4 concurrent files in the folder
 pikpaktui download -n "/My Pack/folder"                 # dry run
 ```
 
 :::callout[Concurrent downloads]{kind="info"}
-`-j` / `--jobs` sets the number of parallel download threads. Values of 2–4 are typical; configurable in `config.toml` as `download_jobs`.
+`-j` / `--jobs` applies to files inside recursive folder downloads. Values of 2–4 are typical; the allowed range is 1–16.
 :::
 
 ---
@@ -329,10 +329,11 @@ If you upload a file that already exists on PikPak (matching hash), the upload c
 
 ## share
 
-Create, list, save, and delete share links.
+Create, browse, list, save, and delete share links.
 
 ```
 pikpaktui share [options] <path...>      # create
+pikpaktui share -b <url> [path]          # browse a share
 pikpaktui share -l                       # list your shares
 pikpaktui share -S <url>                 # save a share to your drive
 pikpaktui share -D <id...>               # delete share(s)
@@ -355,6 +356,13 @@ pikpaktui share -D <id...>               # delete share(s)
 | `-t <path>` | Destination folder in your drive |
 | `-n`, `--dry-run` | Preview without saving |
 
+**Browse options (with `-b` / `--browse`):**
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--pass-code <code>` | Pass code for a protected share |
+| `-J`, `--json` | JSON output |
+
 **Examples:**
 
 ```bash
@@ -366,6 +374,9 @@ pikpaktui share -J "/My Pack/file.txt"            # JSON output
 
 pikpaktui share -l                                # list all your shares
 pikpaktui share -l -J                             # JSON list
+
+pikpaktui share -b "https://mypikpak.com/s/XXXX"             # browse share root
+pikpaktui share -b -p PO "https://mypikpak.com/s/XXXX" Movies # browse a folder
 
 pikpaktui share -D abc123                         # delete one share
 pikpaktui share -D abc123 def456                  # delete multiple
@@ -388,8 +399,9 @@ pikpaktui offline [options] <url>
 | Flag | Description |
 |------|-------------|
 | `--to`, `-t <path>` | Destination folder in PikPak |
-| `--name`, `-n <name>` | Override the task/file name |
-| `--dry-run` | Preview without creating the task |
+| `--name <name>` | Override the task/file name |
+| `-p`, `--preview` | Show URL/magnet contents without creating a task |
+| `-n`, `--dry-run` | Preview without creating the task |
 
 **Examples:**
 
@@ -397,6 +409,7 @@ pikpaktui offline [options] <url>
 pikpaktui offline "magnet:?xt=urn:btih:abc123..."
 pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 pikpaktui offline --to "/Downloads" --name "myvideo.mp4" "https://..."
+pikpaktui offline -p "magnet:?xt=..."             # inspect contents
 pikpaktui offline --dry-run "magnet:?xt=..."
 ```
 
@@ -415,6 +428,7 @@ pikpaktui tasks [subcommand] [options] [limit]
 | Subcommand | Description |
 |------------|-------------|
 | `list`, `ls` | List tasks (default when no subcommand given) |
+| `show <id>` | Poll and show one task's latest state |
 | `retry <id>` | Retry a failed task |
 | `delete <id...>`, `rm <id...>` | Delete task(s) |
 
@@ -432,6 +446,7 @@ pikpaktui tasks [subcommand] [options] [limit]
 pikpaktui tasks                             # list up to 50 tasks
 pikpaktui tasks list 10                    # list 10 tasks
 pikpaktui tasks list --json                # JSON output
+pikpaktui tasks show abc12345              # show latest task state
 pikpaktui tasks retry abc12345             # retry a failed task
 pikpaktui tasks delete abc12345            # delete a task
 pikpaktui tasks rm abc12345 def67890       # delete multiple tasks
@@ -487,6 +502,23 @@ pikpaktui untrash -n "file.txt"         # dry run
 :::callout[tip]{kind="info"}
 Match is by exact filename, not by path. If multiple trashed files share the same name, the first match is restored.
 :::
+
+---
+
+## empty
+
+Permanently delete selected trash items, or empty the entire trash.
+
+```
+pikpaktui empty [-n] [-f] <name...>
+pikpaktui empty [-n] [-f] --all
+```
+
+| Flag | Description |
+|------|-------------|
+| `--all`, `-r`, `--recursive`, `/` | Empty the entire trash |
+| `-f`, `--force` | Skip confirmation when emptying all trash |
+| `-n`, `--dry-run` | Preview without deleting |
 
 ---
 
@@ -573,7 +605,7 @@ pikpaktui events --json
 
 ## login
 
-Log in to PikPak and save credentials to `~/.config/pikpaktui/login.yaml`.
+Log in to PikPak and save credentials to `~/.config/pikpaktui/login.toml`.
 
 ```
 pikpaktui login [options]
@@ -632,6 +664,16 @@ pikpaktui vip
 
 ---
 
+## whoami
+
+Show the identity associated with the current session.
+
+```
+pikpaktui whoami [-J|--json]
+```
+
+---
+
 ## update
 
 Check for updates and self-update the binary from GitHub releases.
@@ -646,7 +688,7 @@ Downloads the latest release for your platform and replaces the current binary i
 
 ## completions
 
-Generate shell completion scripts. Currently only **Zsh** is supported.
+Generate shell completion scripts for Bash, Zsh, Fish, and PowerShell.
 
 ```
 pikpaktui completions <shell>
@@ -658,6 +700,9 @@ pikpaktui completions <shell>
 pikpaktui completions zsh                            # print to stdout
 pikpaktui completions zsh > ~/.zfunc/_pikpaktui      # save to file
 eval "$(pikpaktui completions zsh)"                  # load in current shell
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+pikpaktui completions powershell | Out-String | Invoke-Expression
 ```
 
 See [Shell Completions](/guide/shell-completions) for full setup instructions.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -5,7 +5,7 @@ order: 1
 ---
 
 
-pikpaktui provides 27 CLI subcommands for scripting, automation, and power-user workflows. All commands require a valid session — run `pikpaktui` (TUI) first to log in, or use `pikpaktui login`.
+pikpaktui provides 28 CLI subcommands for scripting, automation, and power-user workflows. All commands require a valid session — run `pikpaktui` (TUI) first to log in, or use `pikpaktui login`.
 
 ## Command Groups
 
@@ -35,7 +35,7 @@ pikpaktui provides 27 CLI subcommands for scripting, automation, and power-user 
 |---------|-------------|
 | [`download`](/cli/commands#download) | Download files or folders |
 | [`upload`](/cli/commands#upload) | Upload files to PikPak |
-| [`share`](/cli/commands#share) | Create, list, save, or delete share links |
+| [`share`](/cli/commands#share) | Create, browse, list, save, or delete share links |
 
 ### Cloud Download
 
@@ -50,6 +50,7 @@ pikpaktui provides 27 CLI subcommands for scripting, automation, and power-user 
 |---------|-------------|
 | [`trash`](/cli/commands#trash) | List trashed files |
 | [`untrash`](/cli/commands#untrash) | Restore files from trash by name |
+| [`empty`](/cli/commands#empty) | Permanently delete selected or all trash items |
 
 ### Starred & Activity
 
@@ -72,6 +73,7 @@ pikpaktui provides 27 CLI subcommands for scripting, automation, and power-user 
 |---------|-------------|
 | [`quota`](/cli/commands#quota) | Storage and bandwidth quota |
 | [`vip`](/cli/commands#vip) | VIP status and account info |
+| [`whoami`](/cli/commands#whoami) | Show the logged-in account identity |
 
 ### Utility
 
@@ -94,7 +96,7 @@ pikpaktui quota --json
 
 ### Dry run
 
-All commands that modify data accept `-n` / `--dry-run`. This resolves paths and prints a detailed plan without making any changes:
+Commands that document `-n` / `--dry-run` resolve paths and print a detailed plan without making changes:
 
 ```bash
 pikpaktui rm -n "/My Pack/file.txt"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,13 +7,13 @@ order: 3
 
 All configuration files live under `~/.config/pikpaktui/`.
 
-## Credentials — `login.yaml`
+## Credentials — `login.toml`
 
 Stores your PikPak account credentials. Created automatically on first login (via TUI or `pikpaktui login`).
 
-```yaml
-username: "you@example.com"
-password: "your-password"
+```toml
+username = "you@example.com"
+password = "your-password"
 ```
 
 You can also set credentials via environment variables for the `login` command:
@@ -29,9 +29,9 @@ Credentials are stored in plain text. Ensure `~/.config/pikpaktui/` has appropri
 ## TUI & CLI Settings — `config.toml`
 
 The main settings file. Edit manually or use the in-TUI settings panel (`,` to open, `s` to save).
+The scalar settings are top-level TOML keys; do not wrap them in a `[tui]` table.
 
 ```toml
-[tui]
 # UI
 nerd_font = false           # Nerd Font icons in TUI (requires a Nerd Font terminal)
 border_style = "thick"      # "rounded" | "thick" | "thick-rounded" | "double"
@@ -58,7 +58,7 @@ cli_nerd_font = false       # Nerd Font icons in CLI output
 player = "mpv"              # External video player command; set in TUI on first video play
 
 # Downloads
-download_jobs = 1           # Concurrent download threads (1–16)
+download_jobs = 1           # TUI download workers (1–16 in the settings UI)
 update_check = "notify"     # "notify" | "quiet" | "off"
 ```
 
@@ -79,7 +79,7 @@ update_check = "notify"
 Configure the image rendering protocol per terminal emulator, keyed by the `$TERM_PROGRAM` environment variable. Detected automatically — entries are added the first time each terminal is used.
 
 ```toml
-[tui.image_protocols]
+[image_protocols]
 ghostty = "kitty"
 "iTerm.app" = "iterm2"
 WezTerm = "auto"
@@ -92,7 +92,7 @@ Supported values: `"auto"` (detect), `"kitty"`, `"iterm2"`, `"sixel"`.
 Used when `color_scheme = "custom"`. Each value is an `[R, G, B]` array (0–255).
 
 ```toml
-[tui.custom_colors]
+[custom_colors]
 folder   = [92, 176, 255]   # Light blue
 archive  = [255, 102, 102]  # Light red
 image    = [255, 102, 255]  # Light magenta
@@ -129,5 +129,5 @@ These override config file values. Useful for CI or per-session overrides.
 | `PIKPAK_CAPTCHA_TOKEN` | CAPTCHA token if login is challenged |
 
 :::callout[Concurrent downloads]{kind="info"}
-Set `download_jobs` to match your bandwidth. Values between 2–4 are typical. Maximum is 16.
+`download_jobs` controls the TUI download queue only; CLI folder downloads use `download -j <n>`. Values between 2–4 are typical, and the TUI settings editor offers 1–16.
 :::

--- a/docs/docs.config.ts
+++ b/docs/docs.config.ts
@@ -2,8 +2,8 @@ export default {
   slug: 'pikpaktui',
   install: {
     linux:   { name: 'Linux',   cmd: 'curl -fsSL https://app.snaix.homes/pikpaktui/install.sh | bash', note: 'debian, ubuntu, arch, alpine, fedora · musl static · x86_64 + arm64' },
-    macos:   { name: 'macOS',   cmd: 'brew install Bengerthelorf/tap/pikpaktui',                     note: 'homebrew; universal binary — arm64 + x86_64' },
-    cargo:   { name: 'Cargo',   cmd: 'cargo install pikpaktui',                                      note: 'builds from crates.io · rust 1.78+' },
+    macos:   { name: 'macOS',   cmd: 'brew install Bengerthelorf/tap/pikpaktui',                     note: 'homebrew; native binaries for arm64 + x86_64' },
+    cargo:   { name: 'Cargo',   cmd: 'cargo install pikpaktui',                                      note: 'builds from crates.io · Rust 1.90+' },
     source:  { name: 'source',  cmd: 'git clone https://github.com/Bengerthelorf/pikpaktui.git && cd pikpaktui && cargo build --release', note: 'binary at ./target/release/pikpaktui' },
   },
   sections: [

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ order: 1
 ---
 
 pikpaktui is a terminal client for [PikPak](https://mypikpak.com) cloud
-storage — an interactive TUI plus a full CLI with 27 subcommands. Pure
+storage — an interactive TUI plus a full CLI with 28 subcommands. Pure
 Rust, no OpenSSL, no C deps.
 
 If you don't have it yet, head to [**install**](/install) first. This
@@ -20,7 +20,7 @@ pikpaktui
 ```
 
 On first run, a login form appears. Enter your PikPak email and password.
-Credentials are saved to `~/.config/pikpaktui/login.yaml` and the session
+Credentials are saved to `~/.config/pikpaktui/login.toml` and the session
 to `~/.config/pikpaktui/session.json`.
 
 ![TUI main view](/images/main.jpeg)
@@ -50,7 +50,7 @@ pikpaktui rm -rf "/My Pack/old-folder"      # permanent
 
 # Transfer
 pikpaktui download "/My Pack/video.mp4"
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4
+pikpaktui download -j 4 "/My Pack/Movies"   # concurrent files within a folder
 pikpaktui upload ./notes.txt "/My Pack"
 
 # Offline
@@ -59,13 +59,13 @@ pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 ```
 
 :::callout[Dry run]{kind="info"}
-Every command that modifies data accepts `-n` / `--dry-run` — resolves
-paths and shows what would happen without doing it.
+Most file and transfer commands accept `-n` / `--dry-run` — check the
+individual command reference before relying on it.
 :::
 
 ## Next Steps
 
 - [TUI Guide](/guide/tui) — every keybinding for every view
 - [Configuration](/guide/configuration) — colors, fonts, player, behavior
-- [CLI Commands](/docs/cli/commands) — full reference for all 27 subcommands
+- [CLI Commands](/docs/cli/commands) — full reference for all 28 subcommands
 - [Shell Completions](/guide/shell-completions) — tab-complete cloud paths

--- a/docs/shell-completions.md
+++ b/docs/shell-completions.md
@@ -38,6 +38,30 @@ pikpaktui completions zsh > \
 Cloud path completions work beautifully with [fzf-tab](https://github.com/Aloxaf/fzf-tab) — you get a fuzzy-searchable popup of your remote files as you type.
 :::
 
+## Bash
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+# Or load for this shell only:
+eval "$(pikpaktui completions bash)"
+```
+
+## Fish
+
+```fish
+mkdir -p ~/.config/fish/completions
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+# Or load for this shell only:
+eval (pikpaktui completions fish | string collect)
+```
+
+## PowerShell
+
+```powershell
+pikpaktui completions powershell | Out-String | Invoke-Expression
+```
+
 ## What Gets Completed
 
 | Context | Completions |
@@ -56,16 +80,16 @@ Cloud path completions work beautifully with [fzf-tab](https://github.com/Aloxaf
 | `pikpaktui share /path<Tab>` | Cloud path completion |
 | `pikpaktui offline --to /dst<Tab>` | Cloud path for `--to` |
 | `pikpaktui offline --name <Tab>` | (free text) |
-| `pikpaktui tasks <Tab>` | `list`, `ls`, `retry`, `delete`, `rm` |
-| `pikpaktui rm -<Tab>` | `-r`, `-f`, `-rf`, `-fr` |
-| `pikpaktui mkdir -<Tab>` | `-p` |
+| `pikpaktui tasks <Tab>` | `list`, `ls`, `show`, `retry`, `delete`, `rm` |
+| `pikpaktui rm -<Tab>` | recursive, force, and dry-run flags |
+| `pikpaktui mkdir -<Tab>` | `-p`, `-n`, `--dry-run` |
 | `pikpaktui info /path<Tab>` | Cloud path |
 | `pikpaktui cat /path<Tab>` | Cloud path |
 | `pikpaktui play /path<Tab>` | Cloud path |
 | `pikpaktui rename /path<Tab>` | Cloud path |
 | `pikpaktui star /path<Tab>` | Cloud path |
 | `pikpaktui unstar /path<Tab>` | Cloud path |
-| `pikpaktui completions <Tab>` | `zsh` |
+| `pikpaktui completions <Tab>` | `bash`, `zsh`, `fish`, `powershell` |
 
 ## How Cloud Path Completion Works
 
@@ -83,4 +107,4 @@ There may be a brief delay on first completion while the API is queried. Subsequ
 
 ## Currently Supported Shells
 
-Only **Zsh** is supported at this time. Fish and Bash completions are not yet available.
+**Bash, Zsh, Fish, and PowerShell** are supported.

--- a/docs/zh-Hant/cli/commands.md
+++ b/docs/zh-Hant/cli/commands.md
@@ -265,7 +265,7 @@ pikpaktui download [選項] -t <本機目錄> <路徑...>
 |------|------|
 | `-o`, `--output <檔案>` | 自訂輸出檔案名稱（僅單一檔案） |
 | `-t <本機目錄>` | 批次模式——將多個檔案下載至指定目錄 |
-| `-j`, `--jobs <n>` | 並行下載執行緒數（預設 1） |
+| `-j`, `--jobs <n>` | 遞迴下載資料夾時的檔案並行數（1–16，預設 1） |
 | `-n`, `--dry-run` | 預覽，不下載 |
 
 **範例：**
@@ -274,7 +274,7 @@ pikpaktui download [選項] -t <本機目錄> <路徑...>
 pikpaktui download "/My Pack/file.txt"
 pikpaktui download -o output.mp4 "/My Pack/video.mp4"
 pikpaktui download "/My Pack/folder"                      # 遞迴下載
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4        # 4 並行批次
+pikpaktui download -j 4 "/My Pack/folder"                # 資料夾內最多 4 個檔案並行
 pikpaktui download -n "/My Pack/folder"
 ```
 
@@ -308,10 +308,11 @@ pikpaktui upload -n ./file.txt "/My Pack"          # 預覽
 
 ## share
 
-建立、列出、儲存和刪除分享連結。
+建立、瀏覽、列出、儲存和刪除分享連結。
 
 ```
 pikpaktui share [選項] <路徑...>      # 建立
+pikpaktui share -b <URL> [路徑]       # 瀏覽分享
 pikpaktui share -l                    # 列出我的分享
 pikpaktui share -S <URL>              # 儲存他人分享至網盤
 pikpaktui share -D <ID...>            # 刪除分享
@@ -334,6 +335,13 @@ pikpaktui share -D <ID...>            # 刪除分享
 | `-t <路徑>` | 儲存目標資料夾 |
 | `-n`, `--dry-run` | 預覽，不儲存 |
 
+**瀏覽選項（與 `-b` / `--browse` 搭配）：**
+
+| 參數 | 說明 |
+|------|------|
+| `-p`, `--pass-code <密碼>` | 加密分享的存取碼 |
+| `-J`, `--json` | JSON 輸出 |
+
 **範例：**
 
 ```bash
@@ -342,6 +350,8 @@ pikpaktui share -p "/My Pack/file.txt"           # 加密分享
 pikpaktui share -d 7 -p /a.txt /b.txt            # 多檔案+加密+7天
 
 pikpaktui share -l                               # 列出我的分享
+pikpaktui share -b "https://mypikpak.com/s/XXXX"             # 瀏覽分享根目錄
+pikpaktui share -b -p PO "https://mypikpak.com/s/XXXX" Movies # 瀏覽子目錄
 pikpaktui share -D abc123                        # 刪除指定分享
 
 pikpaktui share -S "https://mypikpak.com/s/XXXX"
@@ -362,8 +372,9 @@ pikpaktui offline [選項] <URL>
 | 參數 | 說明 |
 |------|------|
 | `--to`, `-t <路徑>` | PikPak 中的目標資料夾 |
-| `--name`, `-n <名稱>` | 覆寫任務/檔案名稱 |
-| `--dry-run` | 預覽，不建立任務 |
+| `--name <名稱>` | 覆寫任務/檔案名稱 |
+| `-p`, `--preview` | 顯示 URL/磁力連結內容，不建立任務 |
+| `-n`, `--dry-run` | 預覽，不建立任務 |
 
 **範例：**
 
@@ -371,6 +382,7 @@ pikpaktui offline [選項] <URL>
 pikpaktui offline "magnet:?xt=urn:btih:abc123..."
 pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 pikpaktui offline --to "/Downloads" --name "myvideo.mp4" "https://..."
+pikpaktui offline -p "magnet:?xt=..."              # 檢視內容
 pikpaktui offline --dry-run "magnet:?xt=..."
 ```
 
@@ -389,6 +401,7 @@ pikpaktui tasks [子指令] [選項] [數量]
 | 子指令 | 說明 |
 |--------|------|
 | `list`、`ls` | 列出任務（不指定時的預設行為） |
+| `show <ID>` | 取得並顯示單一任務的最新狀態 |
 | `retry <ID>` | 重試失敗的任務 |
 | `delete <ID...>`、`rm <ID...>` | 刪除任務 |
 
@@ -406,6 +419,7 @@ pikpaktui tasks [子指令] [選項] [數量]
 pikpaktui tasks
 pikpaktui tasks list 10
 pikpaktui tasks list --json
+pikpaktui tasks show abc12345
 pikpaktui tasks retry abc12345
 pikpaktui tasks delete abc12345
 pikpaktui tasks rm abc12345 def67890
@@ -460,6 +474,23 @@ pikpaktui untrash -n "file.txt"
 
 ---
 
+## empty
+
+永久刪除指定回收桶項目，或清空整個回收桶。
+
+```
+pikpaktui empty [-n] [-f] <檔案名稱...>
+pikpaktui empty [-n] [-f] --all
+```
+
+| 參數 | 說明 |
+|------|------|
+| `--all`、`-r`、`--recursive`、`/` | 清空整個回收桶 |
+| `-f`, `--force` | 清空全部項目時略過確認 |
+| `-n`, `--dry-run` | 預覽，不刪除 |
+
+---
+
 ## star / unstar / starred
 
 ```bash
@@ -500,7 +531,7 @@ pikpaktui events --json
 
 ## login
 
-登入 PikPak 並將憑證儲存至 `~/.config/pikpaktui/login.yaml`。
+登入 PikPak 並將憑證儲存至 `~/.config/pikpaktui/login.toml`。
 
 ```
 pikpaktui login [選項]
@@ -559,6 +590,16 @@ pikpaktui vip
 
 ---
 
+## whoami
+
+顯示目前工作階段對應的帳戶身分。
+
+```
+pikpaktui whoami [-J|--json]
+```
+
+---
+
 ## update
 
 檢查更新並從 GitHub Releases 自動更新二進位檔案。
@@ -573,7 +614,7 @@ pikpaktui update
 
 ## completions
 
-產生 Shell 補全腳本，目前僅支援 **Zsh**。
+產生 Bash、Zsh、Fish 與 PowerShell 的 Shell 補全腳本。
 
 ```
 pikpaktui completions <shell>
@@ -585,6 +626,9 @@ pikpaktui completions <shell>
 pikpaktui completions zsh
 pikpaktui completions zsh > ~/.zfunc/_pikpaktui
 eval "$(pikpaktui completions zsh)"
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+pikpaktui completions powershell | Out-String | Invoke-Expression
 ```
 
 詳見 [Shell 補全](/zh-Hant/guide/shell-completions)。

--- a/docs/zh-Hant/cli/index.md
+++ b/docs/zh-Hant/cli/index.md
@@ -6,7 +6,7 @@ locale: zh-Hant
 ---
 
 
-pikpaktui 提供 27 條 CLI 子指令，適合腳本、自動化與進階使用者。所有指令均需有效工作階段——先執行 `pikpaktui`（TUI）登入，或使用 `pikpaktui login`。
+pikpaktui 提供 28 條 CLI 子指令，適合腳本、自動化與進階使用者。所有指令均需有效工作階段——先執行 `pikpaktui`（TUI）登入，或使用 `pikpaktui login`。
 
 ## 指令分組
 
@@ -36,7 +36,7 @@ pikpaktui 提供 27 條 CLI 子指令，適合腳本、自動化與進階使用�
 |------|------|
 | [`download`](/zh-Hant/cli/commands#download) | 下載檔案或資料夾 |
 | [`upload`](/zh-Hant/cli/commands#upload) | 上傳檔案至 PikPak |
-| [`share`](/zh-Hant/cli/commands#share) | 建立、列出、儲存或刪除分享連結 |
+| [`share`](/zh-Hant/cli/commands#share) | 建立、瀏覽、列出、儲存或刪除分享連結 |
 
 ### 離線下載
 
@@ -51,6 +51,7 @@ pikpaktui 提供 27 條 CLI 子指令，適合腳本、自動化與進階使用�
 |------|------|
 | [`trash`](/zh-Hant/cli/commands#trash) | 列出回收桶中的檔案 |
 | [`untrash`](/zh-Hant/cli/commands#untrash) | 依檔案名稱從回收桶復原檔案 |
+| [`empty`](/zh-Hant/cli/commands#empty) | 永久刪除指定或全部回收桶項目 |
 
 ### 加星號與活動記錄
 
@@ -73,6 +74,7 @@ pikpaktui 提供 27 條 CLI 子指令，適合腳本、自動化與進階使用�
 |------|------|
 | [`quota`](/zh-Hant/cli/commands#quota) | 儲存空間與頻寬配額 |
 | [`vip`](/zh-Hant/cli/commands#vip) | VIP 狀態與帳戶資訊 |
+| [`whoami`](/zh-Hant/cli/commands#whoami) | 顯示目前登入帳戶身分 |
 
 ### 工具程式
 
@@ -95,7 +97,7 @@ pikpaktui quota --json
 
 ### Dry run 預覽
 
-所有修改資料的指令均支援 `-n` / `--dry-run`，解析路徑後顯示操作計畫，不做實際變更：
+參數說明中列出 `-n` / `--dry-run` 的指令會解析路徑並顯示操作計畫，不做實際變更：
 
 ```bash
 pikpaktui rm -n "/My Pack/file.txt"

--- a/docs/zh-Hant/configuration.md
+++ b/docs/zh-Hant/configuration.md
@@ -8,13 +8,13 @@ locale: zh-Hant
 
 所有設定檔位於 `~/.config/pikpaktui/` 目錄下。
 
-## 帳號憑證——`login.yaml`
+## 帳號憑證——`login.toml`
 
 儲存 PikPak 帳號資訊，首次登入（TUI 或 `pikpaktui login`）時自動建立。
 
-```yaml
-username: "you@example.com"
-password: "your-password"
+```toml
+username = "you@example.com"
+password = "your-password"
 ```
 
 也可透過環境變數傳入（用於 `login` 指令）：
@@ -30,9 +30,9 @@ PIKPAK_USER=you@example.com PIKPAK_PASS=yourpassword pikpaktui login
 ## TUI 與 CLI 設定——`config.toml`
 
 主設定檔，可手動編輯，也可在 TUI 設定面板（`,`）中修改後按 `s` 儲存。
+這些純量設定是 TOML 頂層欄位，請勿放入 `[tui]` 表。
 
 ```toml
-[tui]
 # 介面
 nerd_font = false           # TUI 中使用 Nerd Font 圖示（需要 Nerd Font 終端機字型）
 border_style = "thick"      # "rounded" | "thick" | "thick-rounded" | "double"
@@ -59,7 +59,7 @@ cli_nerd_font = false       # CLI 輸出中使用 Nerd Font 圖示
 player = "mpv"              # 外部影片播放器指令；首次播放影片時在 TUI 設定
 
 # 下載
-download_jobs = 1           # 並行下載執行緒數（1–16）
+download_jobs = 1           # TUI 下載工作執行緒數（設定介面範圍 1–16）
 update_check = "notify"    # "notify" | "quiet" | "off"
 ```
 
@@ -80,7 +80,7 @@ update_check = "notify"
 依終端機模擬器設定圖片渲染協定，鍵名為 `$TERM_PROGRAM` 環境變數的值。首次使用該終端機時自動新增項目。
 
 ```toml
-[tui.image_protocols]
+[image_protocols]
 ghostty = "kitty"
 "iTerm.app" = "iterm2"
 WezTerm = "auto"
@@ -93,7 +93,7 @@ WezTerm = "auto"
 當 `color_scheme = "custom"` 時生效，每個值為 `[R, G, B]` 陣列（0–255）。
 
 ```toml
-[tui.custom_colors]
+[custom_colors]
 folder   = [92, 176, 255]   # 淡藍
 archive  = [255, 102, 102]  # 淡紅
 image    = [255, 102, 255]  # 淡品紅
@@ -130,5 +130,5 @@ default  = [255, 255, 255]  # 白色
 | `PIKPAK_CAPTCHA_TOKEN` | 登入遭遇驗證碼時提供 token |
 
 :::callout[並行下載]{kind="info"}
-將 `download_jobs` 設為 2–4 通常可以顯著提升大量下載速度，最大值為 16。
+`download_jobs` 僅控制 TUI 下載佇列；CLI 遞迴下載資料夾請使用 `download -j <n>`。通常建議設為 2–4，TUI 設定介面可選 1–16。
 :::

--- a/docs/zh-Hant/getting-started.md
+++ b/docs/zh-Hant/getting-started.md
@@ -6,7 +6,7 @@ locale: zh-Hant
 ---
 
 
-pikpaktui 是一個 [PikPak](https://mypikpak.com) 雲端儲存的終端機客戶端，提供互動式 TUI 與包含 27 條子指令的完整 CLI。由純 Rust 撰寫，無 OpenSSL，無 C 相依。
+pikpaktui 是一個 [PikPak](https://mypikpak.com) 雲端儲存的終端機客戶端，提供互動式 TUI 與包含 28 條子指令的完整 CLI。由純 Rust 撰寫，無 OpenSSL，無 C 相依。
 
 ## 系統需求
 
@@ -48,7 +48,7 @@ cargo build --release
 pikpaktui
 ```
 
-首次執行會顯示登入表單，輸入 PikPak 電子郵件與密碼。登入成功後，憑證儲存至 `~/.config/pikpaktui/login.yaml`，工作階段儲存至 `~/.config/pikpaktui/session.json`，之後無需再次登入（會自動更新）。
+首次執行會顯示登入表單，輸入 PikPak 電子郵件與密碼。登入成功後，憑證儲存至 `~/.config/pikpaktui/login.toml`，工作階段儲存至 `~/.config/pikpaktui/session.json`，之後無需再次登入（會自動更新）。
 
 ![TUI 主畫面](/images/main.jpeg)
 
@@ -130,7 +130,7 @@ pikpaktui rm -rf "/My Pack/old-folder"    # 永久刪除
 
 # 傳輸
 pikpaktui download "/My Pack/video.mp4"
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4  # 4 並行
+pikpaktui download -j 4 "/My Pack/Movies"  # 資料夾內最多 4 個檔案並行
 pikpaktui upload ./notes.txt "/My Pack"
 
 # 離線下載
@@ -139,7 +139,7 @@ pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 ```
 
 :::callout[Dry run 預覽]{kind="info"}
-所有修改資料的指令均支援 `-n` / `--dry-run`——解析路徑後顯示操作計畫，不做任何實際變更。
+多數檔案與傳輸指令支援 `-n` / `--dry-run`；使用前請查看個別指令的參數說明。
 :::
 
 ## 透過 CLI 登入
@@ -169,5 +169,5 @@ PIKPAK_USER=you@example.com PIKPAK_PASS=yourpassword pikpaktui login
 
 - [TUI 指南](/zh-Hant/guide/tui) — 所有檢視的完整快捷鍵參考
 - [設定](/zh-Hant/guide/configuration) — 自訂配色、字型、播放器等
-- [CLI 指令參考](/zh-Hant/cli/commands) — 全部 27 條指令詳解
+- [CLI 指令參考](/zh-Hant/cli/commands) — 全部 28 條指令詳解
 - [Shell 補全](/zh-Hant/guide/shell-completions) — 在 zsh 中 Tab 補全雲端路徑

--- a/docs/zh-Hant/shell-completions.md
+++ b/docs/zh-Hant/shell-completions.md
@@ -39,6 +39,28 @@ pikpaktui completions zsh > \
 搭配 [fzf-tab](https://github.com/Aloxaf/fzf-tab) 使用效果更佳——輸入路徑前綴後按 Tab 會彈出可模糊搜尋的雲端檔案清單。
 :::
 
+## Bash
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+# 或僅為目前 Shell 載入：
+eval "$(pikpaktui completions bash)"
+```
+
+## Fish
+
+```fish
+mkdir -p ~/.config/fish/completions
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+```
+
+## PowerShell
+
+```powershell
+pikpaktui completions powershell | Out-String | Invoke-Expression
+```
+
 ## 補全涵蓋範圍
 
 | 情境 | 補全內容 |
@@ -55,14 +77,14 @@ pikpaktui completions zsh > \
 | `pikpaktui upload -t /dst<Tab>` | `-t` 目標的雲端路徑 |
 | `pikpaktui share /path<Tab>` | 雲端路徑補全 |
 | `pikpaktui offline --to /dst<Tab>` | `--to` 目標的雲端路徑 |
-| `pikpaktui tasks <Tab>` | `list`、`ls`、`retry`、`delete`、`rm` |
-| `pikpaktui rm -<Tab>` | `-r`、`-f`、`-rf`、`-fr` |
-| `pikpaktui mkdir -<Tab>` | `-p` |
+| `pikpaktui tasks <Tab>` | `list`、`ls`、`show`、`retry`、`delete`、`rm` |
+| `pikpaktui rm -<Tab>` | 遞迴、強制刪除與 dry-run 參數 |
+| `pikpaktui mkdir -<Tab>` | `-p`、`-n`、`--dry-run` |
 | `pikpaktui info /path<Tab>` | 雲端路徑 |
 | `pikpaktui cat /path<Tab>` | 雲端路徑 |
 | `pikpaktui play /path<Tab>` | 雲端路徑 |
 | `pikpaktui rename /path<Tab>` | 雲端路徑 |
-| `pikpaktui completions <Tab>` | `zsh` |
+| `pikpaktui completions <Tab>` | `bash`、`zsh`、`fish`、`powershell` |
 
 ## 雲端路徑補全原理
 
@@ -80,4 +102,4 @@ pikpaktui completions zsh > \
 
 ## 支援的 Shell
 
-目前僅支援 **Zsh**，尚不支援 Fish 和 Bash。
+目前支援 **Bash、Zsh、Fish 與 PowerShell**。

--- a/docs/zh/cli/commands.md
+++ b/docs/zh/cli/commands.md
@@ -271,7 +271,7 @@ pikpaktui download [选项] -t <本地目录> <路径...>
 |------|------|
 | `-o`, `--output <文件>` | 自定义输出文件名（仅单文件） |
 | `-t <本地目录>` | 批量模式——将多个文件下载到指定目录 |
-| `-j`, `--jobs <n>` | 并发下载线程数（默认 1） |
+| `-j`, `--jobs <n>` | 递归下载文件夹时的文件并发数（1–16，默认 1） |
 | `-n`, `--dry-run` | 预览，不下载 |
 
 **示例：**
@@ -281,7 +281,7 @@ pikpaktui download "/My Pack/file.txt"                  # 下载到当前目录
 pikpaktui download "/My Pack/file.txt" /tmp/file.txt    # 下载到指定路径
 pikpaktui download -o output.mp4 "/My Pack/video.mp4"   # 自定义文件名
 pikpaktui download "/My Pack/folder"                    # 递归下载文件夹
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4      # 4 并发，批量
+pikpaktui download -j 4 "/My Pack/folder"              # 文件夹内最多 4 个文件并发
 pikpaktui download -n "/My Pack/folder"                 # 预览
 ```
 
@@ -319,10 +319,11 @@ pikpaktui upload -n ./file.txt "/My Pack"          # 预览
 
 ## share
 
-创建、列出、保存和删除分享链接。
+创建、浏览、列出、保存和删除分享链接。
 
 ```
 pikpaktui share [选项] <路径...>      # 创建
+pikpaktui share -b <URL> [路径]       # 浏览分享
 pikpaktui share -l                    # 列出我的分享
 pikpaktui share -S <URL>              # 保存他人分享到网盘
 pikpaktui share -D <ID...>            # 删除分享
@@ -345,6 +346,13 @@ pikpaktui share -D <ID...>            # 删除分享
 | `-t <路径>` | 保存目标文件夹 |
 | `-n`, `--dry-run` | 预览，不保存 |
 
+**浏览选项（与 `-b` / `--browse` 配合）：**
+
+| 参数 | 说明 |
+|------|------|
+| `-p`, `--pass-code <密码>` | 加密分享的访问码 |
+| `-J`, `--json` | JSON 输出 |
+
 **示例：**
 
 ```bash
@@ -355,6 +363,9 @@ pikpaktui share -p -d 7 /a.txt /b.txt            # 多文件+加密+7天
 
 pikpaktui share -l                               # 列出我的分享
 pikpaktui share -l -J                            # JSON 格式
+
+pikpaktui share -b "https://mypikpak.com/s/XXXX"             # 浏览分享根目录
+pikpaktui share -b -p PO "https://mypikpak.com/s/XXXX" Movies # 浏览子目录
 
 pikpaktui share -D abc123                        # 删除指定分享
 pikpaktui share -D abc123 def456                 # 删除多个
@@ -377,8 +388,9 @@ pikpaktui offline [选项] <URL>
 | 参数 | 说明 |
 |------|------|
 | `--to`, `-t <路径>` | PikPak 中的目标文件夹 |
-| `--name`, `-n <名称>` | 覆盖任务/文件名 |
-| `--dry-run` | 预览，不创建任务 |
+| `--name <名称>` | 覆盖任务/文件名 |
+| `-p`, `--preview` | 显示 URL/磁力链接内容，不创建任务 |
+| `-n`, `--dry-run` | 预览，不创建任务 |
 
 **示例：**
 
@@ -386,6 +398,7 @@ pikpaktui offline [选项] <URL>
 pikpaktui offline "magnet:?xt=urn:btih:abc123..."
 pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 pikpaktui offline --to "/Downloads" --name "myvideo.mp4" "https://..."
+pikpaktui offline -p "magnet:?xt=..."              # 查看内容
 pikpaktui offline --dry-run "magnet:?xt=..."
 ```
 
@@ -404,6 +417,7 @@ pikpaktui tasks [子命令] [选项] [数量]
 | 子命令 | 说明 |
 |--------|------|
 | `list`、`ls` | 列出任务（不指定子命令时的默认行为） |
+| `show <ID>` | 获取并显示单个任务的最新状态 |
 | `retry <ID>` | 重试失败的任务 |
 | `delete <ID...>`、`rm <ID...>` | 删除任务 |
 
@@ -421,6 +435,7 @@ pikpaktui tasks [子命令] [选项] [数量]
 pikpaktui tasks                              # 列出最多 50 条任务
 pikpaktui tasks list 10                     # 列出 10 条
 pikpaktui tasks list --json                 # JSON 输出
+pikpaktui tasks show abc12345               # 显示任务最新状态
 pikpaktui tasks retry abc12345              # 重试失败任务
 pikpaktui tasks delete abc12345             # 删除任务
 pikpaktui tasks rm abc12345 def67890        # 删除多个任务
@@ -476,6 +491,23 @@ pikpaktui untrash -n "file.txt"        # 预览
 :::callout[tip]{kind="info"}
 按精确文件名匹配，不是路径。若多个已删除文件同名，恢复第一个匹配项。
 :::
+
+---
+
+## empty
+
+永久删除指定回收站项目，或清空整个回收站。
+
+```
+pikpaktui empty [-n] [-f] <文件名...>
+pikpaktui empty [-n] [-f] --all
+```
+
+| 参数 | 说明 |
+|------|------|
+| `--all`、`-r`、`--recursive`、`/` | 清空整个回收站 |
+| `-f`, `--force` | 清空全部项目时跳过确认 |
+| `-n`, `--dry-run` | 预览，不删除 |
 
 ---
 
@@ -562,7 +594,7 @@ pikpaktui events --json
 
 ## login
 
-登录 PikPak 并将凭据保存到 `~/.config/pikpaktui/login.yaml`。
+登录 PikPak 并将凭据保存到 `~/.config/pikpaktui/login.toml`。
 
 ```
 pikpaktui login [选项]
@@ -621,6 +653,16 @@ pikpaktui vip
 
 ---
 
+## whoami
+
+显示当前会话对应的账户身份。
+
+```
+pikpaktui whoami [-J|--json]
+```
+
+---
+
 ## update
 
 检查更新并从 GitHub Releases 自动更新二进制文件。
@@ -635,7 +677,7 @@ pikpaktui update
 
 ## completions
 
-生成 Shell 补全脚本，目前仅支持 **Zsh**。
+生成 Bash、Zsh、Fish 和 PowerShell 的 Shell 补全脚本。
 
 ```
 pikpaktui completions <shell>
@@ -647,6 +689,9 @@ pikpaktui completions <shell>
 pikpaktui completions zsh                            # 输出到标准输出
 pikpaktui completions zsh > ~/.zfunc/_pikpaktui      # 保存到文件
 eval "$(pikpaktui completions zsh)"                  # 在当前 shell 中加载
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+pikpaktui completions powershell | Out-String | Invoke-Expression
 ```
 
 详见 [Shell 补全](/zh/guide/shell-completions)。

--- a/docs/zh/cli/index.md
+++ b/docs/zh/cli/index.md
@@ -6,7 +6,7 @@ locale: zh
 ---
 
 
-pikpaktui 提供 27 条 CLI 子命令，适合脚本、自动化和进阶用户。所有命令均需有效会话——先运行 `pikpaktui`（TUI）登录，或使用 `pikpaktui login`。
+pikpaktui 提供 28 条 CLI 子命令，适合脚本、自动化和进阶用户。所有命令均需有效会话——先运行 `pikpaktui`（TUI）登录，或使用 `pikpaktui login`。
 
 ## 命令分组
 
@@ -36,7 +36,7 @@ pikpaktui 提供 27 条 CLI 子命令，适合脚本、自动化和进阶用户�
 |------|------|
 | [`download`](/zh/cli/commands#download) | 下载文件或文件夹 |
 | [`upload`](/zh/cli/commands#upload) | 上传文件到 PikPak |
-| [`share`](/zh/cli/commands#share) | 创建、列出、保存或删除分享链接 |
+| [`share`](/zh/cli/commands#share) | 创建、浏览、列出、保存或删除分享链接 |
 
 ### 离线下载
 
@@ -51,6 +51,7 @@ pikpaktui 提供 27 条 CLI 子命令，适合脚本、自动化和进阶用户�
 |------|------|
 | [`trash`](/zh/cli/commands#trash) | 列出回收站中的文件 |
 | [`untrash`](/zh/cli/commands#untrash) | 按文件名从回收站恢复文件 |
+| [`empty`](/zh/cli/commands#empty) | 永久删除指定或全部回收站项目 |
 
 ### 收藏与动态
 
@@ -73,6 +74,7 @@ pikpaktui 提供 27 条 CLI 子命令，适合脚本、自动化和进阶用户�
 |------|------|
 | [`quota`](/zh/cli/commands#quota) | 存储空间和带宽配额 |
 | [`vip`](/zh/cli/commands#vip) | VIP 状态和账户信息 |
+| [`whoami`](/zh/cli/commands#whoami) | 显示当前登录账户身份 |
 
 ### 工具
 
@@ -95,7 +97,7 @@ pikpaktui quota --json
 
 ### Dry run 预览
 
-所有修改数据的命令均支持 `-n` / `--dry-run`，解析路径后打印操作计划，不做实际修改：
+参数说明中列出 `-n` / `--dry-run` 的命令会解析路径并打印操作计划，不做实际修改：
 
 ```bash
 pikpaktui rm -n "/My Pack/file.txt"

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -8,13 +8,13 @@ locale: zh
 
 所有配置文件位于 `~/.config/pikpaktui/` 目录下。
 
-## 账号凭据——`login.yaml`
+## 账号凭据——`login.toml`
 
 存储 PikPak 账号信息，首次登录（TUI 或 `pikpaktui login`）时自动创建。
 
-```yaml
-username: "you@example.com"
-password: "your-password"
+```toml
+username = "you@example.com"
+password = "your-password"
 ```
 
 也可通过环境变量传入（用于 `login` 命令）：
@@ -30,9 +30,9 @@ PIKPAK_USER=you@example.com PIKPAK_PASS=yourpassword pikpaktui login
 ## TUI 与 CLI 设置——`config.toml`
 
 主配置文件，可手动编辑，也可在 TUI 设置面板（`,`）中修改后按 `s` 保存。
+这些标量设置是 TOML 顶层字段，请勿放进 `[tui]` 表。
 
 ```toml
-[tui]
 # 界面
 nerd_font = false           # TUI 中使用 Nerd Font 图标（需要 Nerd Font 终端字体）
 border_style = "thick"      # "rounded" | "thick" | "thick-rounded" | "double"
@@ -59,7 +59,7 @@ cli_nerd_font = false       # CLI 输出中使用 Nerd Font 图标
 player = "mpv"              # 外部视频播放器命令；首次播放视频时在 TUI 设置
 
 # 下载
-download_jobs = 1           # 并发下载线程数（1–16）
+download_jobs = 1           # TUI 下载工作线程数（设置界面范围 1–16）
 update_check = "notify"     # "notify" | "quiet" | "off"
 ```
 
@@ -68,7 +68,7 @@ update_check = "notify"     # "notify" | "quiet" | "off"
 按终端模拟器配置图片渲染协议，键名为 `$TERM_PROGRAM` 环境变量的值。首次使用该终端时自动添加条目。
 
 ```toml
-[tui.image_protocols]
+[image_protocols]
 ghostty = "kitty"
 "iTerm.app" = "iterm2"
 WezTerm = "auto"
@@ -81,7 +81,7 @@ WezTerm = "auto"
 当 `color_scheme = "custom"` 时生效，每个值为 `[R, G, B]` 数组（0–255）。
 
 ```toml
-[tui.custom_colors]
+[custom_colors]
 folder   = [92, 176, 255]   # 浅蓝
 archive  = [255, 102, 102]  # 浅红
 image    = [255, 102, 255]  # 浅品红
@@ -130,5 +130,5 @@ update_check = "notify"
 ```
 
 :::callout[并发下载]{kind="info"}
-将 `download_jobs` 设为 2–4 通常可以显著提升大批量下载速度，最大值为 16。
+`download_jobs` 仅控制 TUI 下载队列；CLI 递归下载文件夹请使用 `download -j <n>`。通常建议设为 2–4，TUI 设置界面可选 1–16。
 :::

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -6,7 +6,7 @@ locale: zh
 ---
 
 
-pikpaktui 是一个 [PikPak](https://mypikpak.com) 云存储的终端客户端，提供交互式 TUI 和包含 26 条子命令的完整 CLI。由纯 Rust 编写，无 OpenSSL，无 C 依赖。
+pikpaktui 是一个 [PikPak](https://mypikpak.com) 云存储的终端客户端，提供交互式 TUI 和包含 28 条子命令的完整 CLI。由纯 Rust 编写，无 OpenSSL，无 C 依赖。
 
 ## 系统要求
 
@@ -48,7 +48,7 @@ cargo build --release
 pikpaktui
 ```
 
-首次运行会显示登录表单，输入 PikPak 邮箱和密码。登录成功后，凭据保存至 `~/.config/pikpaktui/login.yaml`，会话保存至 `~/.config/pikpaktui/session.json`，之后无需再次登录（会自动刷新）。
+首次运行会显示登录表单，输入 PikPak 邮箱和密码。登录成功后，凭据保存至 `~/.config/pikpaktui/login.toml`，会话保存至 `~/.config/pikpaktui/session.json`，之后无需再次登录（会自动刷新）。
 
 ![TUI 主界面](/images/main.jpeg)
 
@@ -130,7 +130,7 @@ pikpaktui rm -rf "/My Pack/old-folder"    # 永久删除
 
 # 传输
 pikpaktui download "/My Pack/video.mp4"
-pikpaktui download -j4 -t ./videos/ /a.mp4 /b.mp4  # 4 并发
+pikpaktui download -j 4 "/My Pack/Movies"  # 文件夹内最多 4 个文件并发
 pikpaktui upload ./notes.txt "/My Pack"
 
 # 离线下载
@@ -139,7 +139,7 @@ pikpaktui offline --to "/Downloads" "https://example.com/file.zip"
 ```
 
 :::callout[Dry run 预览]{kind="info"}
-所有修改数据的命令都支持 `-n` / `--dry-run`——会解析路径并展示操作计划，不做任何实际修改。
+多数文件与传输命令支持 `-n` / `--dry-run`；使用前请查看对应命令的参数说明。
 :::
 
 ## 通过 CLI 登录
@@ -169,5 +169,5 @@ PIKPAK_USER=you@example.com PIKPAK_PASS=yourpassword pikpaktui login
 
 - [TUI 指南](/zh/guide/tui) — 所有视图的完整快捷键参考
 - [配置](/zh/guide/configuration) — 自定义配色、字体、播放器等
-- [CLI 命令参考](/zh/cli/commands) — 全部 27 条命令详解
+- [CLI 命令参考](/zh/cli/commands) — 全部 28 条命令详解
 - [Shell 补全](/zh/guide/shell-completions) — 在 zsh 中 Tab 补全云端路径

--- a/docs/zh/shell-completions.md
+++ b/docs/zh/shell-completions.md
@@ -39,6 +39,28 @@ pikpaktui completions zsh > \
 搭配 [fzf-tab](https://github.com/Aloxaf/fzf-tab) 使用效果更佳——输入路径前缀后按 Tab 会弹出可模糊搜索的云端文件列表。
 :::
 
+## Bash
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+pikpaktui completions bash > ~/.local/share/bash-completion/completions/pikpaktui
+# 或仅为当前 Shell 加载：
+eval "$(pikpaktui completions bash)"
+```
+
+## Fish
+
+```fish
+mkdir -p ~/.config/fish/completions
+pikpaktui completions fish > ~/.config/fish/completions/pikpaktui.fish
+```
+
+## PowerShell
+
+```powershell
+pikpaktui completions powershell | Out-String | Invoke-Expression
+```
+
 ## 补全覆盖范围
 
 | 场景 | 补全内容 |
@@ -56,16 +78,16 @@ pikpaktui completions zsh > \
 | `pikpaktui upload -t /dst<Tab>` | `-t` 目标的云端路径 |
 | `pikpaktui share /path<Tab>` | 云端路径补全 |
 | `pikpaktui offline --to /dst<Tab>` | `--to` 目标的云端路径 |
-| `pikpaktui tasks <Tab>` | `list`、`ls`、`retry`、`delete`、`rm` |
-| `pikpaktui rm -<Tab>` | `-r`、`-f`、`-rf`、`-fr` |
-| `pikpaktui mkdir -<Tab>` | `-p` |
+| `pikpaktui tasks <Tab>` | `list`、`ls`、`show`、`retry`、`delete`、`rm` |
+| `pikpaktui rm -<Tab>` | 递归、强制删除和 dry-run 参数 |
+| `pikpaktui mkdir -<Tab>` | `-p`、`-n`、`--dry-run` |
 | `pikpaktui info /path<Tab>` | 云端路径 |
 | `pikpaktui cat /path<Tab>` | 云端路径 |
 | `pikpaktui play /path<Tab>` | 云端路径 |
 | `pikpaktui rename /path<Tab>` | 云端路径 |
 | `pikpaktui star /path<Tab>` | 云端路径 |
 | `pikpaktui unstar /path<Tab>` | 云端路径 |
-| `pikpaktui completions <Tab>` | `zsh` |
+| `pikpaktui completions <Tab>` | `bash`、`zsh`、`fish`、`powershell` |
 
 ## 云端路径补全原理
 
@@ -83,4 +105,4 @@ pikpaktui completions zsh > \
 
 ## 支持的 Shell
 
-目前仅支持 **Zsh**，暂不支持 Fish 和 Bash。
+目前支持 **Bash、Zsh、Fish 和 PowerShell**。

--- a/install.sh
+++ b/install.sh
@@ -78,17 +78,27 @@ fi
 
 echo -e "${BLUE}>>> Verifying checksum...${NC}"
 if curl -L --fail --silent --show-error -o "${TMP_DIR}/sha256sums.txt" "$CHECKSUM_URL"; then
+    CHECKSUM_LINE=$(
+        awk -v asset="$ASSET_NAME" \
+            '$2 == asset { print; found = 1 } END { if (!found) exit 1 }' \
+            "${TMP_DIR}/sha256sums.txt"
+    ) || {
+        echo -e "${RED}No checksum found for ${ASSET_NAME}; refusing to install an unverified binary.${NC}"
+        exit 1
+    }
+
     if command -v sha256sum >/dev/null 2>&1; then
-        (cd "$TMP_DIR" && grep "  ${ASSET_NAME}$" sha256sums.txt | sha256sum -c -)
+        (cd "$TMP_DIR" && printf '%s\n' "$CHECKSUM_LINE" | sha256sum -c -)
     elif command -v shasum >/dev/null 2>&1; then
-        (cd "$TMP_DIR" && grep "  ${ASSET_NAME}$" sha256sums.txt | shasum -a 256 -c -)
+        (cd "$TMP_DIR" && printf '%s\n' "$CHECKSUM_LINE" | shasum -a 256 -c -)
     else
         echo -e "${RED}No sha256 tool found; install sha256sum or shasum to verify downloads.${NC}"
         exit 1
     fi
     echo -e "${GREEN}Checksum verified.${NC}"
 else
-    echo -e "${RED}Checksum file not found; skipping verification for this release.${NC}"
+    echo -e "${RED}Checksum file could not be downloaded; refusing to install an unverified binary.${NC}"
+    exit 1
 fi
 
 echo -e "${BLUE}>>> Extracting...${NC}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,33 +44,120 @@ info "Preparing release: $VERSION (tag $TAG)"
 
 cd "$PROJECT_DIR"
 
-if ! git diff --quiet || ! git diff --cached --quiet; then
-    error "Working directory has uncommitted changes. Commit or stash first."
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    error "Releases must be created from the main branch (current: ${CURRENT_BRANCH:-detached HEAD})."
 fi
 
-if git rev-parse "$TAG" >/dev/null 2>&1; then
-    error "Tag $TAG already exists."
+if [[ -n "$(git status --porcelain)" ]]; then
+    error "Working directory is not clean. Commit, stash, or remove all tracked and untracked changes first."
 fi
 
-CURRENT_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+git remote get-url origin >/dev/null 2>&1 || error "Git remote 'origin' is not configured."
+info "Refreshing origin/main and release tags..."
+git fetch --quiet --tags origin "+refs/heads/main:refs/remotes/origin/main"
+
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse refs/remotes/origin/main)" ]]; then
+    error "Local main must exactly match origin/main before release preparation. Push or synchronize existing commits first."
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+    error "Tag $TAG already exists on origin."
+fi
+
+LOCAL_TAG_COMMIT=""
+if git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" >/dev/null; then
+    LOCAL_TAG_COMMIT=$(git rev-parse "refs/tags/$TAG^{commit}")
+    if [[ "$LOCAL_TAG_COMMIT" != "$(git rev-parse HEAD)" ]]; then
+        error "Local tag $TAG exists but does not point to HEAD."
+    fi
+    warn "Local tag $TAG already points to HEAD; it will be reused."
+fi
+
+manifest_version() {
+    awk -F '"' '/^version = "/ { print $2; exit }' Cargo.toml
+}
+
+lock_version() {
+    awk -F '"' \
+        '$0 == "name = \"pikpaktui\"" { getline; if ($0 ~ /^version = "/) { print $2; exit } }' \
+        Cargo.lock
+}
+
+version_is_less() {
+    local left_major left_minor left_patch
+    local right_major right_minor right_patch
+    IFS=. read -r left_major left_minor left_patch <<< "$1"
+    IFS=. read -r right_major right_minor right_patch <<< "$2"
+
+    if (( 10#$left_major != 10#$right_major )); then
+        (( 10#$left_major < 10#$right_major ))
+        return
+    fi
+    if (( 10#$left_minor != 10#$right_minor )); then
+        (( 10#$left_minor < 10#$right_minor ))
+        return
+    fi
+    (( 10#$left_patch < 10#$right_patch ))
+}
+
+CURRENT_VERSION=$(manifest_version)
+[[ -n "$CURRENT_VERSION" ]] || error "Could not read the package version from Cargo.toml."
 info "Current version: $CURRENT_VERSION → $VERSION"
+if version_is_less "$VERSION" "$CURRENT_VERSION"; then
+    error "Refusing to release version $VERSION because it is lower than current version $CURRENT_VERSION."
+fi
 
 # ==============================================================================
 # Step 1: Bump version
 # ==============================================================================
 
-info "Bumping version in Cargo.toml..."
-sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$VERSION\"/" Cargo.toml
+if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+    [[ -z "$LOCAL_TAG_COMMIT" ]] || error "Cannot bump Cargo.toml while local tag $TAG already exists."
 
-info "Updating Cargo.lock..."
-cargo generate-lockfile --quiet
+    info "Bumping version in Cargo.toml..."
+    CARGO_TMP=$(mktemp "$PROJECT_DIR/.Cargo.toml.XXXXXX")
+    cleanup_release_tmp() {
+        if [[ -n "${CARGO_TMP:-}" && -f "$CARGO_TMP" ]]; then
+            rm -f -- "$CARGO_TMP"
+        fi
+    }
+    trap cleanup_release_tmp EXIT
+
+    if ! awk -v version="$VERSION" '
+        BEGIN { replaced = 0 }
+        !replaced && /^version = "/ {
+            print "version = \"" version "\""
+            replaced = 1
+            next
+        }
+        { print }
+        END { if (!replaced) exit 1 }
+    ' Cargo.toml > "$CARGO_TMP"; then
+        error "Could not update the package version in Cargo.toml."
+    fi
+    mv "$CARGO_TMP" Cargo.toml
+    CARGO_TMP=""
+
+    info "Synchronizing Cargo.lock..."
+    cargo check --quiet
+else
+    info "Cargo.toml already has version $VERSION; no version bump commit is needed."
+fi
+
+if [[ "$(manifest_version)" != "$VERSION" ]]; then
+    error "Cargo.toml version does not match requested release $VERSION."
+fi
+if [[ "$(lock_version)" != "$VERSION" ]]; then
+    error "Cargo.lock version does not match requested release $VERSION."
+fi
 
 # ==============================================================================
 # Step 2: Run tests
 # ==============================================================================
 
 info "Running tests..."
-cargo test --quiet
+cargo test --quiet --locked
 
 info "All tests passed."
 
@@ -78,15 +165,28 @@ info "All tests passed."
 # Step 3: Commit, tag, and push
 # ==============================================================================
 
-info "Committing version bump..."
-git add Cargo.toml Cargo.lock
-git commit -m "chore: bump version to $VERSION"
+if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+    CHANGED_FILES=$(git diff --name-only)
+    EXPECTED_FILES=$'Cargo.lock\nCargo.toml'
+    if [[ "$(printf '%s\n' "$CHANGED_FILES" | sort)" != "$EXPECTED_FILES" ]]; then
+        error "Version preparation changed unexpected tracked files:\n$CHANGED_FILES"
+    fi
 
-git tag "$TAG"
+    info "Committing version bump..."
+    git add Cargo.toml Cargo.lock
+    git commit -m "chore: bump version to $VERSION"
+fi
 
-info "Pushing to remote..."
-git push origin main
-git push origin "$TAG"
+if [[ -n "$(git status --porcelain)" ]]; then
+    error "Working directory changed during release preparation; refusing to tag."
+fi
+
+if [[ -z "$LOCAL_TAG_COMMIT" ]]; then
+    git tag "$TAG"
+fi
+
+info "Pushing main and $TAG atomically..."
+git push --atomic origin "HEAD:refs/heads/main" "refs/tags/$TAG"
 
 info "============================================"
 info "Tag $TAG pushed!"

--- a/src/cmd/completions.rs
+++ b/src/cmd/completions.rs
@@ -82,11 +82,16 @@ _pikpaktui() {
         'events:Recent file events'
         'trash:List trashed files'
         'untrash:Restore files from trash'
+        'empty:Permanently delete items from trash'
         'info:Show detailed file/folder info'
+        'link:Get direct download URL'
         'cat:Preview text file contents'
         'play:Play video with external player'
         'quota:Show storage quota'
         'vip:Show VIP & account info'
+        'whoami:Show logged-in account identity'
+        'login:Log in and save credentials'
+        'update:Check for updates and self-update'
         'completions:Generate shell completions'
         'help:Show help message'
         'version:Show version'
@@ -101,7 +106,7 @@ _pikpaktui() {
     case "$cmd" in
         ls)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-l' '--long' '-s' '--sort' '-r' '--reverse'
+                compadd -- '-l' '--long' '-J' '--json' '-s' '--sort' '-r' '--reverse' '--tree' '--depth'
             elif [[ "${words[CURRENT-1]}" == "-s" ]] || [[ "${words[CURRENT-1]}" == "--sort" ]]; then
                 compadd -- 'name' 'size' 'created' 'type' 'extension' 'none'
             else
@@ -110,7 +115,7 @@ _pikpaktui() {
             ;;
         mv|cp)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-t'
+                compadd -- '-t' '-n' '--dry-run'
             elif [[ "${words[CURRENT-1]}" == "-t" ]]; then
                 _pikpaktui_cloud_path
             else
@@ -118,28 +123,30 @@ _pikpaktui() {
             fi
             ;;
         rename)
-            if (( CURRENT == 3 )); then
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                compadd -- '-n' '--dry-run'
+            elif (( CURRENT == 3 )); then
                 _pikpaktui_cloud_path
             fi
             ;;
         rm)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-r' '-f' '-rf' '-fr'
+                compadd -- '-r' '--recursive' '-f' '--force' '-rf' '-fr' '-n' '--dry-run'
             else
                 _pikpaktui_cloud_path
             fi
             ;;
         mkdir)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-p'
+                compadd -- '-p' '-n' '--dry-run'
             else
                 _pikpaktui_cloud_path
             fi
             ;;
         download)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-o'
-            elif [[ "${words[CURRENT-1]}" == "-o" ]]; then
+                compadd -- '-o' '--output' '-t' '-j' '--jobs' '-n' '--dry-run'
+            elif [[ "${words[CURRENT-1]}" == "-o" ]] || [[ "${words[CURRENT-1]}" == "--output" ]] || [[ "${words[CURRENT-1]}" == "-t" ]]; then
                 _files
             else
                 _pikpaktui_cloud_path
@@ -147,7 +154,7 @@ _pikpaktui() {
             ;;
         upload)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-t'
+                compadd -- '-t' '-n' '--dry-run'
             elif [[ "${words[CURRENT-1]}" == "-t" ]]; then
                 _pikpaktui_cloud_path
             else
@@ -156,26 +163,31 @@ _pikpaktui() {
             ;;
         share)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-o'
+                compadd -- '-p' '--password' '--pass-code' '-d' '--days' '-o' '-l' '--list' '-S' '--save' '-b' '--browse' '-D' '--delete' '-t' '--to' '-J' '--json' '-n' '--dry-run'
             elif [[ "${words[CURRENT-1]}" == "-o" ]]; then
                 _files
+            elif [[ "${words[CURRENT-1]}" == "-t" ]] || [[ "${words[CURRENT-1]}" == "--to" ]]; then
+                _pikpaktui_cloud_path
             else
                 _pikpaktui_cloud_path
             fi
             ;;
         offline)
             if [[ "${words[CURRENT]}" == -* ]]; then
-                compadd -- '-t' '--to' '-n' '--name'
+                compadd -- '-t' '--to' '--name' '-p' '--preview' '-n' '--dry-run'
             elif [[ "${words[CURRENT-1]}" == "-t" ]] || [[ "${words[CURRENT-1]}" == "--to" ]]; then
                 _pikpaktui_cloud_path
             fi
             ;;
         tasks)
-            if (( CURRENT == 3 )); then
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                compadd -- '-J' '--json' '-n' '--dry-run'
+            elif (( CURRENT == 3 )); then
                 local -a subcmds
                 subcmds=(
                     'list:List offline tasks'
                     'ls:List offline tasks'
+                    'show:Show one task'
                     'retry:Retry a failed task'
                     'delete:Delete task(s)'
                     'rm:Delete task(s)'
@@ -183,8 +195,47 @@ _pikpaktui() {
                 _describe -t subcmds 'tasks subcommand' subcmds
             fi
             ;;
-        star|unstar|info|cat|play)
+        empty)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '--all' '-r' '--recursive' '-f' '--force' '-n' '--dry-run'
+            ;;
+        star|unstar)
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                compadd -- '-n' '--dry-run'
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        info)
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                compadd -- '-J' '--json'
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        link)
+            if [[ "${words[CURRENT]}" == -* ]]; then
+                compadd -- '-m' '--media' '-c' '--copy' '-J' '--json'
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        cat|play)
             _pikpaktui_cloud_path
+            ;;
+        starred|trash)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '-l' '--long' '-J' '--json'
+            ;;
+        events)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '-J' '--json'
+            ;;
+        untrash)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '-n' '--dry-run'
+            ;;
+        login)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '-u' '--user' '-p' '--password'
+            ;;
+        whoami|quota)
+            [[ "${words[CURRENT]}" == -* ]] && compadd -- '-J' '--json'
             ;;
         completions)
             if (( CURRENT == 3 )); then
@@ -234,11 +285,10 @@ _pikpaktui_cloud_path() {
     fi
     [[ "$dir" == "//" ]] && dir="/"
 
-    local IFS=$'\n'
-    local -a entries
-    mapfile -t entries < <("$bin" __complete_path "$dir" 2>/dev/null)
-    for entry in "${entries[@]}"; do
+    local entry
+    while IFS= read -r entry; do
         [[ -z "$entry" ]] && continue
+        [[ -n "$partial" && "$entry" != "$partial"* ]] && continue
         local full_path
         if [[ "$dir" == "/" ]]; then
             full_path="/${entry}"
@@ -246,8 +296,19 @@ _pikpaktui_cloud_path() {
             full_path="${dir}${entry}"
         fi
         COMPREPLY+=("$full_path")
-    done
-    compopt -o nospace 2>/dev/null
+    done < <("$bin" __complete_path "$dir" 2>/dev/null)
+    if type compopt >/dev/null 2>&1; then
+        compopt -o nospace
+    fi
+}
+
+_pikpaktui_local_path() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local entry
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        COMPREPLY+=("$entry")
+    done < <(compgen -f -- "$cur")
 }
 
 _pikpaktui() {
@@ -257,8 +318,8 @@ _pikpaktui() {
     COMPREPLY=()
 
     local commands="ls mv cp rename rm mkdir download upload share offline tasks \
-star unstar starred events trash untrash info link cat play quota vip login \
-update completions help version"
+star unstar starred events trash untrash empty info link cat play quota vip \
+whoami login update completions help version"
 
     if [[ ${COMP_CWORD} -eq 1 ]]; then
         COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -283,11 +344,15 @@ update completions help version"
             fi
             ;;
         rename)
-            _pikpaktui_cloud_path
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-n --dry-run" -- "$cur"))
+            else
+                _pikpaktui_cloud_path
+            fi
             ;;
         rm)
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-r --recursive -f --force -rf -fr" -- "$cur"))
+                COMPREPLY=($(compgen -W "-r --recursive -f --force -rf -fr -n --dry-run" -- "$cur"))
             else
                 _pikpaktui_cloud_path
             fi
@@ -302,8 +367,8 @@ update completions help version"
         download)
             if [[ "$cur" == -* ]]; then
                 COMPREPLY=($(compgen -W "-o --output -t -j --jobs -n --dry-run" -- "$cur"))
-            elif [[ "$prev" == "-o" ]] || [[ "$prev" == "--output" ]]; then
-                COMPREPLY=($(compgen -f -- "$cur"))
+            elif [[ "$prev" == "-o" ]] || [[ "$prev" == "--output" ]] || [[ "$prev" == "-t" ]]; then
+                _pikpaktui_local_path
             else
                 _pikpaktui_cloud_path
             fi
@@ -314,13 +379,15 @@ update completions help version"
             elif [[ "$prev" == "-t" ]]; then
                 _pikpaktui_cloud_path
             else
-                COMPREPLY=($(compgen -f -- "$cur"))
+                _pikpaktui_local_path
             fi
             ;;
         share)
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-p --password -d --days -o -l -S -D -J --json -n --dry-run" -- "$cur"))
-            elif [[ "$prev" == "-t" ]]; then
+                COMPREPLY=($(compgen -W "-p --password --pass-code -d --days -o -l --list -S --save -b --browse -D --delete -t --to -J --json -n --dry-run" -- "$cur"))
+            elif [[ "$prev" == "-o" ]]; then
+                _pikpaktui_local_path
+            elif [[ "$prev" == "-t" ]] || [[ "$prev" == "--to" ]]; then
                 _pikpaktui_cloud_path
             else
                 _pikpaktui_cloud_path
@@ -328,18 +395,71 @@ update completions help version"
             ;;
         offline)
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=($(compgen -W "-t --to -n --dry-run" -- "$cur"))
+                COMPREPLY=($(compgen -W "-t --to --name -p --preview -n --dry-run" -- "$cur"))
             elif [[ "$prev" == "-t" ]] || [[ "$prev" == "--to" ]]; then
                 _pikpaktui_cloud_path
             fi
             ;;
         tasks)
-            if [[ ${COMP_CWORD} -eq 2 ]]; then
-                COMPREPLY=($(compgen -W "list ls retry delete rm" -- "$cur"))
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-J --json -n --dry-run" -- "$cur"))
+            elif [[ ${COMP_CWORD} -eq 2 ]]; then
+                COMPREPLY=($(compgen -W "list ls show retry delete rm" -- "$cur"))
             fi
             ;;
-        star|unstar|info|link|cat|play|trash)
+        star|unstar)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-n --dry-run" -- "$cur"))
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        info)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-J --json" -- "$cur"))
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        link)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-m --media -c --copy -J --json" -- "$cur"))
+            else
+                _pikpaktui_cloud_path
+            fi
+            ;;
+        cat|play)
             _pikpaktui_cloud_path
+            ;;
+        starred|trash)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-l --long -J --json" -- "$cur"))
+            fi
+            ;;
+        events)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-J --json" -- "$cur"))
+            fi
+            ;;
+        untrash)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-n --dry-run" -- "$cur"))
+            fi
+            ;;
+        empty)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "--all -r --recursive -f --force -n --dry-run" -- "$cur"))
+            fi
+            ;;
+        login)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-u --user -p --password" -- "$cur"))
+            fi
+            ;;
+        whoami|quota)
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=($(compgen -W "-J --json" -- "$cur"))
+            fi
             ;;
         completions)
             if [[ ${COMP_CWORD} -eq 2 ]]; then
@@ -363,11 +483,9 @@ function __pikpaktui_cloud_path
     set -l bin (commandline -opc)[1]
 
     set -l dir "/"
-    set -l partial $cur
-
-    if string match -qr '^(.*/)([^/]*)$' -- $cur
-        set dir $MATCH[2]
-        set partial $MATCH[3]
+    if string match -q "*/*" -- $cur
+        set dir (string replace -r '[^/]*$' '' -- $cur)
+        test -n "$dir"; or set dir "/"
     end
 
     set -l entries ($bin __complete_path $dir 2>/dev/null)
@@ -385,13 +503,18 @@ function __pikpaktui_using_command
     test (count $cmd) -ge 2 -a "$cmd[2]" = "$argv[1]"
 end
 
+function __pikpaktui_prev_is
+    set -l cmd (commandline -opc)
+    test (count $cmd) -ge 2; and contains -- $cmd[-1] $argv
+end
+
 # Disable default file completion for pikpaktui
 complete -c pikpaktui -f
 
 # Top-level commands
 set -l subcommands ls mv cp rename rm mkdir download upload share offline tasks \
-    star unstar starred events trash untrash info link cat play quota vip login \
-    update completions help version
+    star unstar starred events trash untrash empty info link cat play quota vip \
+    whoami login update completions help version
 
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a ls         -d "List files"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a mv         -d "Move files"
@@ -410,12 +533,14 @@ complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a starr
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a events     -d "Recent events"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a trash      -d "Trashed files"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a untrash    -d "Restore from trash"
+complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a empty      -d "Permanently delete from trash"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a info       -d "File info"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a link       -d "Direct download URL"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a cat        -d "Preview text file"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a play       -d "Play video"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a quota      -d "Storage quota"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a vip        -d "VIP info"
+complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a whoami     -d "Account identity"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a login      -d "Login"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a update     -d "Update binary"
 complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a completions -d "Generate completions"
@@ -425,6 +550,17 @@ complete -c pikpaktui -n "not __fish_seen_subcommand_from $subcommands" -a versi
 # completions: shell name
 complete -c pikpaktui -n "__pikpaktui_using_command completions" -a "bash zsh fish powershell"
 
+# Context-aware path candidates
+complete -c pikpaktui -n "__pikpaktui_using_command ls; and not __pikpaktui_prev_is -s --sort --depth" -a "(__pikpaktui_cloud_path)"
+complete -c pikpaktui -n "__pikpaktui_using_command mv; or __pikpaktui_using_command cp; or __pikpaktui_using_command rename; or __pikpaktui_using_command rm; or __pikpaktui_using_command mkdir; or __pikpaktui_using_command star; or __pikpaktui_using_command unstar; or __pikpaktui_using_command info; or __pikpaktui_using_command link; or __pikpaktui_using_command cat; or __pikpaktui_using_command play" -a "(__pikpaktui_cloud_path)"
+complete -c pikpaktui -n "__pikpaktui_using_command download; and not __pikpaktui_prev_is -o --output -t -j --jobs" -a "(__pikpaktui_cloud_path)"
+complete -c pikpaktui -n "__pikpaktui_using_command download; and __pikpaktui_prev_is -o --output -t" -F
+complete -c pikpaktui -n "__pikpaktui_using_command upload; and __pikpaktui_prev_is -t" -a "(__pikpaktui_cloud_path)"
+complete -c pikpaktui -n "__pikpaktui_using_command upload; and not __pikpaktui_prev_is -t" -F
+complete -c pikpaktui -n "__pikpaktui_using_command share; and __pikpaktui_prev_is -o" -F
+complete -c pikpaktui -n "__pikpaktui_using_command share; and not __pikpaktui_prev_is -o -d --days --pass-code" -a "(__pikpaktui_cloud_path)"
+complete -c pikpaktui -n "__pikpaktui_using_command offline; and __pikpaktui_prev_is -t --to" -a "(__pikpaktui_cloud_path)"
+
 # ls options
 complete -c pikpaktui -n "__pikpaktui_using_command ls" -s l -l long    -d "Long format"
 complete -c pikpaktui -n "__pikpaktui_using_command ls" -s J -l json    -d "JSON output"
@@ -433,8 +569,55 @@ complete -c pikpaktui -n "__pikpaktui_using_command ls" -s r -l reverse -d "Reve
 complete -c pikpaktui -n "__pikpaktui_using_command ls" -l tree         -d "Tree view"
 complete -c pikpaktui -n "__pikpaktui_using_command ls" -l depth        -d "Max depth"
 
+# File operation and transfer options
+complete -c pikpaktui -n "__pikpaktui_using_command mv; or __pikpaktui_using_command cp" -s t -d "Batch destination"
+complete -c pikpaktui -n "__pikpaktui_using_command mv; or __pikpaktui_using_command cp; or __pikpaktui_using_command rename; or __pikpaktui_using_command mkdir; or __pikpaktui_using_command download; or __pikpaktui_using_command upload" -s n -l dry-run -d "Preview without executing"
+complete -c pikpaktui -n "__pikpaktui_using_command rm" -s r -l recursive -d "Remove folders recursively"
+complete -c pikpaktui -n "__pikpaktui_using_command rm" -s f -l force -d "Permanently delete"
+complete -c pikpaktui -n "__pikpaktui_using_command rm" -s n -l dry-run -d "Preview without executing"
+complete -c pikpaktui -n "__pikpaktui_using_command mkdir" -s p -d "Create intermediate directories"
+complete -c pikpaktui -n "__pikpaktui_using_command download" -s o -l output -d "Output file"
+complete -c pikpaktui -n "__pikpaktui_using_command download; or __pikpaktui_using_command upload" -s t -d "Batch destination"
+complete -c pikpaktui -n "__pikpaktui_using_command download" -s j -l jobs -d "Concurrent downloads"
+
+# Share and cloud-download options
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s p -l password -d "Password-protect a new share"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -l pass-code -d "Share pass code"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s d -l days -d "Expiry in days"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s o -d "Write share URL to file"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s l -l list -d "List shares"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s S -l save -d "Save a share"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s b -l browse -d "Browse a share"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s D -l delete -d "Delete shares"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s t -l to -d "Destination folder"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command share" -s n -l dry-run -d "Preview without saving"
+complete -c pikpaktui -n "__pikpaktui_using_command offline" -s t -l to -d "Destination folder"
+complete -c pikpaktui -n "__pikpaktui_using_command offline" -l name -d "Custom task name"
+complete -c pikpaktui -n "__pikpaktui_using_command offline" -s p -l preview -d "Inspect without adding"
+complete -c pikpaktui -n "__pikpaktui_using_command offline" -s n -l dry-run -d "Preview without creating"
+
 # tasks subcommands
-complete -c pikpaktui -n "__pikpaktui_using_command tasks" -a "list ls retry delete rm"
+complete -c pikpaktui -n "__pikpaktui_using_command tasks" -a "list ls show retry delete rm"
+complete -c pikpaktui -n "__pikpaktui_using_command tasks" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command tasks" -s n -l dry-run -d "Preview without executing"
+
+# Account, auth, and trash options
+complete -c pikpaktui -n "__pikpaktui_using_command empty" -l all -d "Empty all trash"
+complete -c pikpaktui -n "__pikpaktui_using_command empty" -s r -l recursive -d "Empty all trash"
+complete -c pikpaktui -n "__pikpaktui_using_command empty" -s f -l force -d "Skip confirmation"
+complete -c pikpaktui -n "__pikpaktui_using_command empty" -s n -l dry-run -d "Preview without deleting"
+complete -c pikpaktui -n "__pikpaktui_using_command login" -s u -l user -d "Account email"
+complete -c pikpaktui -n "__pikpaktui_using_command login" -s p -l password -d "Account password"
+complete -c pikpaktui -n "__pikpaktui_using_command whoami; or __pikpaktui_using_command quota" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command star; or __pikpaktui_using_command unstar" -s n -l dry-run -d "Preview without changing stars"
+complete -c pikpaktui -n "__pikpaktui_using_command info" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command link" -s m -l media -d "Show media stream URLs"
+complete -c pikpaktui -n "__pikpaktui_using_command link" -s c -l copy -d "Copy URL to clipboard"
+complete -c pikpaktui -n "__pikpaktui_using_command link" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command starred; or __pikpaktui_using_command trash" -s l -l long -d "Long format"
+complete -c pikpaktui -n "__pikpaktui_using_command starred; or __pikpaktui_using_command trash; or __pikpaktui_using_command events" -s J -l json -d "JSON output"
+complete -c pikpaktui -n "__pikpaktui_using_command untrash" -s n -l dry-run -d "Preview without restoring"
 "##;
 
 const POWERSHELL_COMPLETION: &str = r##"# PowerShell completion for pikpaktui - PikPak cloud storage CLI/TUI
@@ -447,6 +630,11 @@ Register-ArgumentCompleter -Native -CommandName @('pikpaktui') -ScriptBlock {
 
     $elements = $commandAst.CommandElements
     $command  = if ($elements.Count -gt 1) { $elements[1].ToString() } else { "" }
+    $binary   = if ($elements.Count -gt 0) { $elements[0].ToString() } else { "pikpaktui" }
+    $currentIsElement = $wordToComplete -ne "" -and
+        $elements.Count -gt 0 -and $elements[-1].ToString() -eq $wordToComplete
+    $previousIndex = if ($currentIsElement) { $elements.Count - 2 } else { $elements.Count - 1 }
+    $previous = if ($previousIndex -ge 0) { $elements[$previousIndex].ToString() } else { "" }
 
     function Get-CloudPaths {
         param([string]$prefix)
@@ -460,10 +648,11 @@ Register-ArgumentCompleter -Native -CommandName @('pikpaktui') -ScriptBlock {
             $partial = ""
         }
         try {
-            $entries = & pikpaktui __complete_path $dir 2>$null
+            $entries = & $binary __complete_path $dir 2>$null
             foreach ($entry in $entries) {
                 $fullPath = if ($dir -eq "/") { "/$entry" } else { "$dir$entry" }
-                if ($partial -eq "" -or $fullPath -like "*$partial*") {
+                if ($partial -eq "" -or
+                    $entry.StartsWith($partial, [System.StringComparison]::OrdinalIgnoreCase)) {
                     [System.Management.Automation.CompletionResult]::new(
                         $fullPath, $fullPath, 'ParameterValue', $fullPath)
                 }
@@ -471,11 +660,39 @@ Register-ArgumentCompleter -Native -CommandName @('pikpaktui') -ScriptBlock {
         } catch {}
     }
 
+    function Get-LocalPaths {
+        param([string]$prefix)
+        $slash = [Math]::Max($prefix.LastIndexOf('/'), $prefix.LastIndexOf('\'))
+        if ($slash -ge 0) {
+            $displayDir = $prefix.Substring(0, $slash + 1)
+            $leaf = $prefix.Substring($slash + 1)
+            $searchDir = $displayDir
+        } else {
+            $displayDir = ""
+            $leaf = $prefix
+            $searchDir = "."
+        }
+        try {
+            Get-ChildItem -LiteralPath $searchDir -Force -ErrorAction Stop |
+                Where-Object {
+                    $_.Name.StartsWith($leaf, [System.StringComparison]::OrdinalIgnoreCase)
+                } |
+                ForEach-Object {
+                    $candidate = "$displayDir$($_.Name)"
+                    if ($_.PSIsContainer) {
+                        $candidate += [System.IO.Path]::DirectorySeparatorChar
+                    }
+                    [System.Management.Automation.CompletionResult]::new(
+                        $candidate, $candidate, 'ParameterValue', $candidate)
+                }
+        } catch {}
+    }
+
     $allCommands = @(
         'ls','mv','cp','rename','rm','mkdir','download','upload','share',
         'offline','tasks','star','unstar','starred','events','trash','untrash',
-        'info','link','cat','play','quota','vip','login','update','completions',
-        'help','version'
+        'empty','info','link','cat','play','quota','vip','whoami','login',
+        'update','completions','help','version'
     )
 
     # Top-level: no sub-command typed yet (or user is still completing the command name)
@@ -495,7 +712,12 @@ Register-ArgumentCompleter -Native -CommandName @('pikpaktui') -ScriptBlock {
                 }
         }
         "tasks" {
-            @('list','ls','retry','delete','rm') |
+            $candidates = if ($wordToComplete.StartsWith('-')) {
+                @('-J','--json','-n','--dry-run')
+            } else {
+                @('list','ls','show','retry','delete','rm')
+            }
+            $candidates |
                 Where-Object { $_ -like "$wordToComplete*" } |
                 ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
@@ -509,22 +731,70 @@ Register-ArgumentCompleter -Native -CommandName @('pikpaktui') -ScriptBlock {
                     'mv'       { @('-t','-n','--dry-run') }
                     'cp'       { @('-t','-n','--dry-run') }
                     'rename'   { @('-n','--dry-run') }
-                    'rm'       { @('-r','--recursive','-f','--force','-rf','-fr') }
+                    'rm'       { @('-r','--recursive','-f','--force','-rf','-fr','-n','--dry-run') }
                     'mkdir'    { @('-p','-n','--dry-run') }
                     'download' { @('-o','--output','-t','-j','--jobs','-n','--dry-run') }
                     'upload'   { @('-t','-n','--dry-run') }
-                    'share'    { @('-p','--password','-d','--days','-o','-l','-S','-D','-J','--json','-n','--dry-run') }
-                    'offline'  { @('-t','--to','-n','--dry-run') }
+                    'share'    { @('-p','--password','--pass-code','-d','--days','-o','-l','--list','-S','--save','-b','--browse','-D','--delete','-t','--to','-J','--json','-n','--dry-run') }
+                    'offline'  { @('-t','--to','--name','-p','--preview','-n','--dry-run') }
+                    'star'     { @('-n','--dry-run') }
+                    'unstar'   { @('-n','--dry-run') }
+                    'info'     { @('-J','--json') }
+                    'link'     { @('-m','--media','-c','--copy','-J','--json') }
+                    'trash'    { @('-l','--long','-J','--json') }
                     default    { @() }
                 }
                 $opts | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
                     [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
                 }
+            } elseif ($command -eq 'download' -and $previous -in @('-o','--output','-t')) {
+                Get-LocalPaths $wordToComplete
+            } elseif ($command -eq 'upload' -and $previous -ne '-t') {
+                Get-LocalPaths $wordToComplete
+            } elseif ($command -eq 'share' -and $previous -eq '-o') {
+                Get-LocalPaths $wordToComplete
+            } elseif ($command -eq 'offline' -and $previous -notin @('-t','--to')) {
+                return
+            } elseif ($command -eq 'trash') {
+                return
             } else {
                 Get-CloudPaths $wordToComplete
             }
         }
-        default { Get-CloudPaths $wordToComplete }
+        { $_ -in @('starred','events','untrash') } {
+            $opts = switch ($command) {
+                'starred' { @('-l','--long','-J','--json') }
+                'events'  { @('-J','--json') }
+                'untrash' { @('-n','--dry-run') }
+            }
+            $opts |
+                Where-Object { $_ -like "$wordToComplete*" } |
+                ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+        }
+        "empty" {
+            @('--all','-r','--recursive','-f','--force','-n','--dry-run') |
+                Where-Object { $_ -like "$wordToComplete*" } |
+                ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+        }
+        "login" {
+            @('-u','--user','-p','--password') |
+                Where-Object { $_ -like "$wordToComplete*" } |
+                ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+        }
+        { $_ -in @('whoami','quota') } {
+            @('-J','--json') |
+                Where-Object { $_ -like "$wordToComplete*" } |
+                ForEach-Object {
+                    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+                }
+        }
+        default {}
     }
 }
 "##;
@@ -561,6 +831,13 @@ pub fn run(args: &[String]) -> Result<()> {
 mod tests {
     use super::*;
 
+    fn public_commands() -> impl Iterator<Item = &'static str> {
+        crate::cmd::COMMAND_GROUPS
+            .iter()
+            .flat_map(|(_, commands)| commands.iter().copied())
+            .chain(["help", "version"])
+    }
+
     // ── Zsh ──────────────────────────────────────────────────────────────────
 
     #[test]
@@ -580,36 +857,10 @@ mod tests {
 
     #[test]
     fn zsh_output_contains_all_commands() {
-        let commands = [
-            "ls:",
-            "mv:",
-            "cp:",
-            "rename:",
-            "rm:",
-            "mkdir:",
-            "download:",
-            "upload:",
-            "share:",
-            "offline:",
-            "tasks:",
-            "star:",
-            "unstar:",
-            "starred:",
-            "events:",
-            "trash:",
-            "untrash:",
-            "info:",
-            "cat:",
-            "play:",
-            "quota:",
-            "vip:",
-            "completions:",
-            "help:",
-            "version:",
-        ];
-        for cmd in commands {
+        for command in public_commands() {
+            let cmd = format!("'{command}:");
             assert!(
-                ZSH_COMPLETION.contains(cmd),
+                ZSH_COMPLETION.contains(&cmd),
                 "Missing command in zsh completion: {cmd}"
             );
         }
@@ -647,36 +898,14 @@ mod tests {
 
     #[test]
     fn bash_output_contains_all_commands() {
-        let commands = [
-            "ls",
-            "mv",
-            "cp",
-            "rename",
-            "rm",
-            "mkdir",
-            "download",
-            "upload",
-            "share",
-            "offline",
-            "tasks",
-            "star",
-            "unstar",
-            "starred",
-            "events",
-            "trash",
-            "untrash",
-            "info",
-            "cat",
-            "play",
-            "quota",
-            "vip",
-            "completions",
-            "help",
-            "version",
-        ];
-        for cmd in commands {
+        let command_list = BASH_COMPLETION
+            .split("local commands=\"")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .expect("bash top-level command list");
+        for cmd in public_commands() {
             assert!(
-                BASH_COMPLETION.contains(cmd),
+                command_list.split_whitespace().any(|entry| entry == cmd),
                 "Missing command in bash completion: {cmd}"
             );
         }
@@ -696,36 +925,10 @@ mod tests {
 
     #[test]
     fn fish_output_contains_all_commands() {
-        let commands = [
-            "ls",
-            "mv",
-            "cp",
-            "rename",
-            "rm",
-            "mkdir",
-            "download",
-            "upload",
-            "share",
-            "offline",
-            "tasks",
-            "star",
-            "unstar",
-            "starred",
-            "events",
-            "trash",
-            "untrash",
-            "info",
-            "cat",
-            "play",
-            "quota",
-            "vip",
-            "completions",
-            "help",
-            "version",
-        ];
-        for cmd in commands {
+        for cmd in public_commands() {
+            let directive = format!("-a {cmd} ");
             assert!(
-                FISH_COMPLETION.contains(cmd),
+                FISH_COMPLETION.contains(&directive),
                 "Missing command in fish completion: {cmd}"
             );
         }
@@ -755,36 +958,15 @@ mod tests {
 
     #[test]
     fn powershell_output_contains_all_commands() {
-        let commands = [
-            "'ls'",
-            "'mv'",
-            "'cp'",
-            "'rename'",
-            "'rm'",
-            "'mkdir'",
-            "'download'",
-            "'upload'",
-            "'share'",
-            "'offline'",
-            "'tasks'",
-            "'star'",
-            "'unstar'",
-            "'starred'",
-            "'events'",
-            "'trash'",
-            "'untrash'",
-            "'info'",
-            "'cat'",
-            "'play'",
-            "'quota'",
-            "'vip'",
-            "'completions'",
-            "'help'",
-            "'version'",
-        ];
-        for cmd in commands {
+        let command_list = POWERSHELL_COMPLETION
+            .split("$allCommands = @(")
+            .nth(1)
+            .and_then(|rest| rest.split(')').next())
+            .expect("PowerShell top-level command list");
+        for command in public_commands() {
+            let cmd = format!("'{command}'");
             assert!(
-                POWERSHELL_COMPLETION.contains(cmd),
+                command_list.contains(&cmd),
                 "Missing command in powershell completion: {cmd}"
             );
         }
@@ -793,6 +975,278 @@ mod tests {
     #[test]
     fn powershell_output_lists_all_four_shells() {
         assert!(POWERSHELL_COMPLETION.contains("'bash','zsh','fish','powershell'"));
+    }
+
+    #[test]
+    fn all_shells_complete_current_tasks_subcommands() {
+        for (shell, script) in [
+            ("zsh", ZSH_COMPLETION),
+            ("bash", BASH_COMPLETION),
+            ("fish", FISH_COMPLETION),
+            ("powershell", POWERSHELL_COMPLETION),
+        ] {
+            assert!(
+                script.contains("show"),
+                "{shell} completion is missing `tasks show`"
+            );
+        }
+    }
+
+    #[test]
+    fn all_shells_complete_current_offline_options() {
+        for (shell, script) in [
+            ("zsh", ZSH_COMPLETION),
+            ("bash", BASH_COMPLETION),
+            ("fish", FISH_COMPLETION),
+            ("powershell", POWERSHELL_COMPLETION),
+        ] {
+            for option in ["--name", "--preview", "--dry-run"] {
+                let needle = if shell == "fish" {
+                    format!("-l {}", option.trim_start_matches('-'))
+                } else {
+                    option.to_string()
+                };
+                assert!(
+                    script.contains(&needle),
+                    "{shell} completion is missing `offline {option}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_shells_complete_current_share_modes() {
+        for (shell, script) in [
+            ("zsh", ZSH_COMPLETION),
+            ("bash", BASH_COMPLETION),
+            ("fish", FISH_COMPLETION),
+            ("powershell", POWERSHELL_COMPLETION),
+        ] {
+            for option in ["--browse", "--save", "--list", "--delete"] {
+                let needle = if shell == "fish" {
+                    format!("-l {}", option.trim_start_matches('-'))
+                } else {
+                    option.to_string()
+                };
+                assert!(
+                    script.contains(&needle),
+                    "{shell} completion is missing `share {option}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fish_wires_dynamic_cloud_path_candidates_into_completions() {
+        assert!(
+            FISH_COMPLETION.contains("-a \"(__pikpaktui_cloud_path)\""),
+            "Fish defines the cloud-path helper but never uses its candidates"
+        );
+    }
+
+    #[test]
+    fn fish_reenables_local_file_candidates_only_for_local_path_contexts() {
+        for command in ["download", "upload"] {
+            let directive = format!("__pikpaktui_using_command {command}");
+            assert!(
+                FISH_COMPLETION
+                    .lines()
+                    .any(|line| line.contains(&directive) && line.contains(" -F")),
+                "Fish does not enable local file completion for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn bash_distinguishes_local_download_targets_from_cloud_sources() {
+        assert!(
+            BASH_COMPLETION.contains(
+                r#""$prev" == "-o" ]] || [[ "$prev" == "--output" ]] || [[ "$prev" == "-t""#
+            ),
+            "Bash must complete download -o/--output/-t values as local paths"
+        );
+    }
+
+    #[test]
+    fn powershell_distinguishes_local_transfer_paths_from_cloud_paths() {
+        assert!(POWERSHELL_COMPLETION.contains("function Get-LocalPaths"));
+        assert!(
+            POWERSHELL_COMPLETION.contains(r#"$previous -in @('-o','--output','-t')"#),
+            "PowerShell must treat download output and -t values as local paths"
+        );
+        assert!(
+            POWERSHELL_COMPLETION.contains(r#"$command -eq 'upload' -and $previous -ne '-t'"#),
+            "PowerShell must treat upload source paths as local paths"
+        );
+    }
+
+    #[test]
+    fn every_shell_exposes_flags_supported_by_existing_parsers() {
+        fn case_arm<'a>(script: &'a str, marker: &str) -> &'a str {
+            let marker = format!("\n        {marker})");
+            script
+                .split_once(&marker)
+                .unwrap_or_else(|| panic!("missing shell case arm {marker}"))
+                .1
+                .split_once("\n            ;;")
+                .expect("unterminated shell case arm")
+                .0
+        }
+
+        let shell_case_contracts: &[(&str, &[&str])] = &[
+            ("star|unstar", &["--dry-run"]),
+            ("info", &["--json"]),
+            ("link", &["--media", "--copy", "--json"]),
+            ("starred|trash", &["--long", "--json"]),
+            ("events", &["--json"]),
+            ("untrash", &["--dry-run"]),
+        ];
+        for (shell, script) in [("zsh", ZSH_COMPLETION), ("bash", BASH_COMPLETION)] {
+            for (marker, options) in shell_case_contracts {
+                let arm = case_arm(script, marker);
+                for option in *options {
+                    assert!(
+                        arm.contains(option),
+                        "{shell} completion case `{marker}` is missing `{option}`"
+                    );
+                }
+            }
+        }
+
+        let line_contracts: &[(&str, &[&str])] = &[
+            ("star", &["--dry-run"]),
+            ("unstar", &["--dry-run"]),
+            ("info", &["--json"]),
+            ("link", &["--media", "--copy", "--json"]),
+            ("starred", &["--long", "--json"]),
+            ("events", &["--json"]),
+            ("trash", &["--long", "--json"]),
+            ("untrash", &["--dry-run"]),
+        ];
+        for (shell, script) in [
+            ("fish", FISH_COMPLETION),
+            ("powershell", POWERSHELL_COMPLETION),
+        ] {
+            for (command, options) in line_contracts {
+                for option in *options {
+                    let option_needle = if shell == "fish" {
+                        format!("-l {}", option.trim_start_matches('-'))
+                    } else {
+                        option.to_string()
+                    };
+                    let command_needle = if shell == "fish" {
+                        format!("__pikpaktui_using_command {command}")
+                    } else {
+                        format!("'{command}'")
+                    };
+                    assert!(
+                        script.lines().any(|line| {
+                            line.contains(&command_needle) && line.contains(&option_needle)
+                        }),
+                        "{shell} completion is missing `{command} {option}`"
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bash_cloud_completion_works_without_the_mapfile_builtin() {
+        use std::os::unix::fs::PermissionsExt as _;
+        use std::process::Command;
+
+        let fixture = std::env::current_dir()
+            .unwrap()
+            .join("target")
+            .join(format!("completion-bash32-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&fixture);
+        std::fs::create_dir_all(&fixture).unwrap();
+
+        let completion_path = fixture.join("pikpaktui-completion.bash");
+        std::fs::write(&completion_path, BASH_COMPLETION).unwrap();
+        let mock_path = fixture.join("pikpaktui-mock");
+        std::fs::write(
+            &mock_path,
+            "#!/bin/bash\nif [[ \"$1\" == \"__complete_path\" ]]; then\n  printf 'Alpha/\\nbeta.txt\\n'\nfi\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&mock_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&mock_path, permissions).unwrap();
+
+        let output = Command::new("bash")
+            .args([
+                "-c",
+                r#"
+enable -n mapfile 2>/dev/null || true
+source "$1"
+COMP_WORDS=("$2" "ls" "/A")
+COMP_CWORD=2
+_pikpaktui
+printf '%s\n' "${COMPREPLY[@]}"
+"#,
+                "completion-test",
+            ])
+            .arg(&completion_path)
+            .arg(&mock_path)
+            .output()
+            .unwrap();
+
+        let _ = std::fs::remove_dir_all(&fixture);
+        assert!(
+            output.status.success(),
+            "bash completion failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "/Alpha/\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bash_local_completion_preserves_spaces_in_file_names() {
+        use std::process::Command;
+
+        let fixture = std::env::current_dir()
+            .unwrap()
+            .join("target")
+            .join(format!("completion-bash-spaces-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&fixture);
+        std::fs::create_dir_all(&fixture).unwrap();
+
+        let completion_path = fixture.join("pikpaktui-completion.bash");
+        std::fs::write(&completion_path, BASH_COMPLETION).unwrap();
+        let local_path = fixture.join("download result.txt");
+        std::fs::write(&local_path, b"fixture").unwrap();
+        let partial_path = fixture.join("download").to_string_lossy().into_owned();
+
+        let output = Command::new("bash")
+            .args([
+                "-c",
+                r#"
+source "$1"
+COMP_WORDS=("pikpaktui" "download" "-o" "$2")
+COMP_CWORD=3
+_pikpaktui
+printf '<%s>\n' "${COMPREPLY[@]}"
+"#,
+                "completion-test",
+            ])
+            .arg(&completion_path)
+            .arg(&partial_path)
+            .output()
+            .unwrap();
+
+        let _ = std::fs::remove_dir_all(&fixture);
+        assert!(
+            output.status.success(),
+            "bash completion failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            format!("<{}>\n", local_path.display())
+        );
     }
 
     // ── run() dispatch ────────────────────────────────────────────────────────

--- a/src/cmd/download.rs
+++ b/src/cmd/download.rs
@@ -1,6 +1,21 @@
 use crate::pikpak::EntryKind;
 use anyhow::{Result, anyhow};
 
+fn destination_path(
+    output: Option<&str>,
+    positional_output: Option<&str>,
+    remote_name: &str,
+) -> std::path::PathBuf {
+    match output.or(positional_output) {
+        Some(explicit) => std::path::PathBuf::from(explicit),
+        None => std::path::PathBuf::from(crate::pikpak::sanitize_filename(remote_name)),
+    }
+}
+
+fn target_destination(target_dir: &std::path::Path, remote_name: &str) -> std::path::PathBuf {
+    target_dir.join(crate::pikpak::sanitize_filename(remote_name))
+}
+
 pub fn run(args: &[String]) -> Result<()> {
     if args.is_empty() {
         return Err(anyhow!(
@@ -25,6 +40,9 @@ pub fn run(args: &[String]) -> Result<()> {
                     .map_err(|_| anyhow!("-j requires a positive integer"))?;
                 if jobs == 0 {
                     return Err(anyhow!("-j must be at least 1"));
+                }
+                if jobs > 16 {
+                    return Err(anyhow!("-j must be at most 16"));
                 }
             }
             "-o" | "--output" => {
@@ -83,7 +101,7 @@ pub fn run(args: &[String]) -> Result<()> {
                     "[dry-run] Would download '{}' ({}) -> '{}'",
                     name,
                     kind_tag,
-                    dir.join(&name).display()
+                    target_destination(dir, &name).display()
                 );
                 continue;
             }
@@ -108,7 +126,7 @@ pub fn run(args: &[String]) -> Result<()> {
                     return Err(anyhow!("{} file(s) failed in '{}'", failed, name));
                 }
             } else {
-                let dest = dir.join(&name);
+                let dest = target_destination(dir, &name);
                 if let Some(parent) = dest.parent()
                     && !parent.as_os_str().is_empty()
                 {
@@ -133,9 +151,7 @@ pub fn run(args: &[String]) -> Result<()> {
         let parent_id = client.resolve_path(&parent)?;
         let entry = super::find_entry(&client, &parent_id, &name)?;
 
-        let dest = std::path::PathBuf::from(
-            output.unwrap_or_else(|| paths.get(1).map(|s| s.as_ref()).unwrap_or(&name)),
-        );
+        let dest = destination_path(output, paths.get(1).map(|s| s.as_ref()), &name);
 
         if dry_run {
             let kind_tag = if entry.kind == EntryKind::Folder {
@@ -201,4 +217,42 @@ pub fn run(args: &[String]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jobs_above_sixteen_are_rejected_before_client_setup() {
+        let err = run(&["-j".into(), "17".into()]).unwrap_err();
+        assert!(
+            err.to_string().contains("at most 16"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn implicit_destination_sanitizes_remote_path_components() {
+        assert_eq!(
+            destination_path(None, None, r"..\outside/file.txt"),
+            std::path::PathBuf::from("__outside_file.txt")
+        );
+        assert_eq!(
+            target_destination(std::path::Path::new("/safe"), r"..\outside/file.txt"),
+            std::path::PathBuf::from("/safe/__outside_file.txt")
+        );
+    }
+
+    #[test]
+    fn explicit_destination_is_preserved_verbatim() {
+        assert_eq!(
+            destination_path(Some("../chosen/name"), None, "remote.txt"),
+            std::path::PathBuf::from("../chosen/name")
+        );
+        assert_eq!(
+            destination_path(None, Some("../positional/name"), "remote.txt"),
+            std::path::PathBuf::from("../positional/name")
+        );
+    }
 }

--- a/src/cmd/mkdir.rs
+++ b/src/cmd/mkdir.rs
@@ -1,5 +1,34 @@
 use anyhow::{Result, anyhow};
 
+fn unique_existing_folder(
+    entries: Vec<crate::pikpak::Entry>,
+    name: &str,
+    full_path: &str,
+) -> Result<Option<crate::pikpak::Entry>> {
+    let mut matches: Vec<_> = entries
+        .into_iter()
+        .filter(|entry| entry.name == name && entry.kind == crate::pikpak::EntryKind::Folder)
+        .collect();
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        count => {
+            let ids = matches
+                .iter()
+                .map(|entry| format!("  id: {}", entry.id))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(anyhow!(
+                "folder '{}' in path '{}' is ambiguous: {} folders share this name:\n{}\nrename one first (or operate on it in the TUI)",
+                name,
+                full_path,
+                count,
+                ids
+            ))
+        }
+    }
+}
+
 pub fn run(args: &[String]) -> Result<()> {
     if args.is_empty() {
         return Err(anyhow!(
@@ -50,10 +79,8 @@ pub fn run(args: &[String]) -> Result<()> {
                 }
                 accumulated.push_str(seg);
                 let entries = client.ls(&current_id)?;
-                if let Some(existing) = entries
-                    .into_iter()
-                    .find(|e| e.name == *seg && e.kind == crate::pikpak::EntryKind::Folder)
-                {
+                let display_path = format!("/{accumulated}");
+                if let Some(existing) = unique_existing_folder(entries, seg, &display_path)? {
                     println!("  /{} (exists, id: {})", accumulated, existing.id);
                     current_id = existing.id;
                 } else {
@@ -69,14 +96,17 @@ pub fn run(args: &[String]) -> Result<()> {
             return Ok(());
         }
 
+        let mut accumulated = String::new();
         for seg in &segments {
+            if !accumulated.is_empty() {
+                accumulated.push('/');
+            }
+            accumulated.push_str(seg);
             let entries = client.ls(&current_id)?;
             // Only a folder counts as "exists": matching a same-named file
             // would make it the parent id for the next mkdir call.
-            if let Some(existing) = entries
-                .into_iter()
-                .find(|e| e.name == *seg && e.kind == crate::pikpak::EntryKind::Folder)
-            {
+            let display_path = format!("/{accumulated}");
+            if let Some(existing) = unique_existing_folder(entries, seg, &display_path)? {
                 current_id = existing.id;
             } else {
                 let entry = client.mkdir(&current_id, seg)?;
@@ -109,4 +139,32 @@ pub fn run(args: &[String]) -> Result<()> {
         println!("Created folder '{}' (id={})", created.name, created.id);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pikpak::{Entry, EntryKind};
+
+    fn folder(id: &str, name: &str) -> Entry {
+        Entry {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: EntryKind::Folder,
+            size: 0,
+            created_time: String::new(),
+            modified_time: String::new(),
+            starred: false,
+            thumbnail_link: None,
+        }
+    }
+
+    #[test]
+    fn recursive_mkdir_rejects_duplicate_existing_folders() {
+        let entries = vec![folder("first", "docs"), folder("second", "docs")];
+
+        let err = unique_existing_folder(entries, "docs", "/docs").unwrap_err();
+
+        assert!(format!("{err:#}").contains("ambiguous"));
+    }
 }

--- a/src/cmd/share.rs
+++ b/src/cmd/share.rs
@@ -36,6 +36,77 @@ fn extract_share_id(share_url: &str) -> &str {
     }
 }
 
+fn load_share_path(
+    inner_path: &str,
+    mut load_folder: impl FnMut(&str) -> Result<Vec<crate::pikpak::ShareEntry>>,
+) -> Result<Vec<crate::pikpak::ShareEntry>> {
+    // `/share` establishes status and pass_code_token, but its `files` field is
+    // only one page. Always enter through the paginated `/share/detail` loader,
+    // including for the root folder.
+    let mut entries = load_folder("")?;
+    let mut walked = String::new();
+    for seg in inner_path
+        .trim_matches('/')
+        .split('/')
+        .filter(|s| !s.is_empty())
+    {
+        let matches: Vec<_> = entries
+            .iter()
+            .filter(|entry| entry.name == seg && entry.is_folder())
+            .collect();
+        let folder_id = match matches.as_slice() {
+            [] => {
+                return Err(anyhow!(
+                    "folder not found in share: '{}{}'",
+                    terminal_safe_text(&walked),
+                    terminal_safe_text(seg)
+                ));
+            }
+            [folder] => folder.id.clone(),
+            duplicates => {
+                let ids = duplicates
+                    .iter()
+                    .map(|entry| format!("  id: {}", terminal_safe_text(&entry.id)))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                return Err(anyhow!(
+                    "folder '{}' in share path '{}{}' is ambiguous: {} folders share this name:\n{}",
+                    terminal_safe_text(seg),
+                    terminal_safe_text(&walked),
+                    terminal_safe_text(seg),
+                    duplicates.len(),
+                    ids
+                ));
+            }
+        };
+        entries = load_folder(&folder_id)?;
+        walked.push_str(seg);
+        walked.push('/');
+    }
+    Ok(entries)
+}
+
+fn terminal_safe_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| {
+            if ch.is_control()
+                || matches!(
+                    ch,
+                    '\u{061c}'
+                        | '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                )
+            {
+                '\u{fffd}'
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
 fn run_browse(args: &[String]) -> Result<()> {
     let mut share_url: Option<&str> = None;
     let mut inner_path: Option<&str> = None;
@@ -75,24 +146,9 @@ fn run_browse(args: &[String]) -> Result<()> {
     let spinner = super::Spinner::new("Fetching share...");
     let info = client.share_info(share_id, pass_code)?;
 
-    // Walk the requested path folder by folder: share_info only exposes the
-    // top level, everything deeper comes from share/detail.
-    let mut entries = info.files;
-    let mut walked = String::new();
-    for seg in inner_path
-        .unwrap_or("")
-        .trim_matches('/')
-        .split('/')
-        .filter(|s| !s.is_empty())
-    {
-        let folder = entries
-            .iter()
-            .find(|e| e.name == seg && e.is_folder())
-            .ok_or_else(|| anyhow!("folder not found in share: '{}{}'", walked, seg))?;
-        entries = client.share_detail(share_id, &folder.id, &info.pass_code_token)?;
-        walked.push_str(seg);
-        walked.push('/');
-    }
+    let entries = load_share_path(inner_path.unwrap_or(""), |parent_id| {
+        client.share_detail(share_id, parent_id, &info.pass_code_token)
+    })?;
     drop(spinner);
 
     if json {
@@ -116,8 +172,9 @@ fn run_browse(args: &[String]) -> Result<()> {
         return Ok(());
     }
     for e in &entries {
+        let name = terminal_safe_text(&e.name);
         if e.is_folder() {
-            println!("  \x1b[1;34m{}/\x1b[0m", e.name);
+            println!("  \x1b[1;34m{}/\x1b[0m", name);
         } else {
             let size = e
                 .size
@@ -125,7 +182,7 @@ fn run_browse(args: &[String]) -> Result<()> {
                 .and_then(|s| s.parse::<u64>().ok())
                 .map(super::format_size)
                 .unwrap_or_default();
-            println!("  {}  \x1b[2m{}\x1b[0m", e.name, size);
+            println!("  {}  \x1b[2m{}\x1b[0m", name, size);
         }
     }
     Ok(())
@@ -258,48 +315,58 @@ fn run_save(args: &[String]) -> Result<()> {
     let dest_display = to_path.unwrap_or("/");
 
     if !json {
-        println!("Fetching share info for '{}'...", share_id);
+        println!(
+            "Fetching share info for '{}'...",
+            terminal_safe_text(share_id)
+        );
     }
     let info = client.share_info(share_id, pass_code)?;
+    let entries = load_share_path("", |parent_id| {
+        client.share_detail(share_id, parent_id, &info.pass_code_token)
+    })?;
 
-    if info.files.is_empty() {
+    if entries.is_empty() {
         return Err(anyhow!("share contains no files"));
     }
 
     if dry_run || !json {
-        println!("Found {} item(s):", info.files.len());
-        for f in &info.files {
-            println!("  {}", f.name);
+        println!("Found {} item(s):", entries.len());
+        for f in &entries {
+            println!("  {}", terminal_safe_text(&f.name));
         }
     }
 
     if dry_run {
         println!(
             "[dry-run] Would save {} item(s) to '{}'",
-            info.files.len(),
-            dest_display
+            entries.len(),
+            terminal_safe_text(dest_display)
         );
         return Ok(());
     }
 
-    let file_ids: Vec<&str> = info.files.iter().map(|f| f.id.as_str()).collect();
+    let file_ids: Vec<&str> = entries.iter().map(|f| f.id.as_str()).collect();
     if !json {
-        println!("Saving to '{}'...", dest_display);
+        println!("Saving to '{}'...", terminal_safe_text(dest_display));
     }
     client.save_share(share_id, &info.pass_code_token, &file_ids, &to_parent_id)?;
 
     if json {
         let out = serde_json::json!({
-            "saved": info.files.len(),
+            "saved": entries.len(),
             "to": dest_display,
-            "files": info.files.iter().map(|f| serde_json::json!({
+            "files": entries.iter().map(|f| serde_json::json!({
                 "id": f.id,
                 "name": f.name,
             })).collect::<Vec<_>>(),
         });
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
-        println!("Saved {} item(s) to '{}'", info.files.len(), dest_display);
+        println!(
+            "Saved {} item(s) to '{}'",
+            entries.len(),
+            terminal_safe_text(dest_display)
+        );
     }
 
     Ok(())
@@ -380,13 +447,13 @@ fn run_list(args: &[String]) -> Result<()> {
             Row {
                 type_str,
                 type_color,
-                title: s.title.clone(),
-                expiry,
-                files,
-                views,
-                saves,
-                date,
-                url: s.share_url.clone(),
+                title: terminal_safe_text(&s.title),
+                expiry: terminal_safe_text(&expiry),
+                files: terminal_safe_text(&files),
+                views: terminal_safe_text(&views),
+                saves: terminal_safe_text(&saves),
+                date: terminal_safe_text(&date),
+                url: terminal_safe_text(&s.share_url),
             }
         })
         .collect();
@@ -461,4 +528,73 @@ fn run_delete(args: &[String]) -> Result<()> {
     client.delete_shares(&ids)?;
     println!("Deleted {} share(s).", ids.len());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pikpak::ShareEntry;
+
+    fn folder(id: &str, name: &str) -> ShareEntry {
+        ShareEntry {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: "drive#folder".to_string(),
+            size: None,
+        }
+    }
+
+    fn file(id: &str, name: &str) -> ShareEntry {
+        ShareEntry {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: "drive#file".to_string(),
+            size: Some("7".to_string()),
+        }
+    }
+
+    #[test]
+    fn browse_empty_path_loads_the_paginated_root() {
+        let mut requested = Vec::new();
+        let entries = load_share_path("", |parent_id| {
+            requested.push(parent_id.to_string());
+            Ok(vec![file("second-page", "visible.txt")])
+        })
+        .unwrap();
+
+        assert_eq!(requested, vec![""]);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "second-page");
+    }
+
+    #[test]
+    fn browse_rejects_duplicate_folder_names() {
+        let err = load_share_path("docs", |_| {
+            Ok(vec![folder("first", "docs"), folder("second", "docs")])
+        })
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("ambiguous"));
+    }
+
+    #[test]
+    fn terminal_text_contains_no_untrusted_control_characters() {
+        let safe = terminal_safe_text("report\u{1b}]52;c;Zm9v\u{7}\rforged\n.txt");
+
+        assert!(!safe.chars().any(char::is_control), "{safe:?}");
+        assert!(safe.contains("report"));
+        assert!(safe.contains("forged"));
+    }
+
+    #[test]
+    fn terminal_text_replaces_bidi_formatting_controls() {
+        let safe = terminal_safe_text(
+            "left\u{061c}\u{200e}\u{200f}\u{202a}\u{202b}\u{202c}\u{202d}\u{202e}\u{2066}\u{2067}\u{2068}\u{2069}right",
+        );
+
+        assert_eq!(
+            safe,
+            "left\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}right"
+        );
+    }
 }

--- a/src/pikpak/account.rs
+++ b/src/pikpak/account.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 
 use super::{PikPak, QuotaInfo, TransferQuotaResponse, VipInfoResponse, json_or_api_error};
 
@@ -7,10 +7,8 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("drive/v1/about");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("quota request failed")?;
+        let rb = self.http.get(&url).bearer_auth(&token);
+        let response = self.send_authed("quota", rb)?;
         json_or_api_error(response, "quota")
     }
 
@@ -18,10 +16,8 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("drive/v1/privilege/vip");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("vip info request failed")?;
+        let rb = self.http.get(&url).bearer_auth(&token);
+        let response = self.send_authed("vip info", rb)?;
         json_or_api_error(response, "vip info")
     }
 
@@ -29,10 +25,8 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("vip/v1/activity/inviteCode");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("invite code request failed")?;
+        let rb = self.http.get(&url).bearer_auth(&token);
+        let response = self.send_authed("invite code", rb)?;
         let data: serde_json::Value = json_or_api_error(response, "invite code")?;
         data["code"]
             .as_str()
@@ -45,10 +39,8 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.auth_url("v1/user/me");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("user info request failed")?;
+        let rb = self.http.get(&url).bearer_auth(&token);
+        let response = self.send_authed("user info", rb)?;
         json_or_api_error(response, "user info")
     }
 
@@ -56,14 +48,12 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("vip/v1/quantity/list");
 
-        let mut rb = self
+        let rb = self
             .http
             .get(&url)
             .bearer_auth(&token)
             .query(&[("type", "transfer")]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("transfer quota request failed")?;
+        let response = self.send_authed("transfer quota", rb)?;
         json_or_api_error(response, "transfer quota")
     }
 }

--- a/src/pikpak/auth.rs
+++ b/src/pikpak/auth.rs
@@ -15,5 +15,7 @@ pub(super) struct CaptchaInitResponse {
     #[serde(default)]
     pub(super) captcha_token: Option<String>,
     #[serde(default)]
+    pub(super) expires_in: u64,
+    #[serde(default)]
     pub(super) url: Option<String>,
 }

--- a/src/pikpak/download.rs
+++ b/src/pikpak/download.rs
@@ -2,7 +2,10 @@ use anyhow::{Context, Result, anyhow};
 use std::fs;
 use std::io;
 use std::io::Read as _;
+use std::io::Write as _;
 use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 
 use super::{Entry, EntryKind, PikPak, sanitize_filename};
 
@@ -12,6 +15,202 @@ pub(crate) fn part_path(dest: &Path) -> std::path::PathBuf {
     let mut os = dest.as_os_str().to_owned();
     os.push(".part");
     std::path::PathBuf::from(os)
+}
+
+fn part_identity_path(dest: &Path) -> std::path::PathBuf {
+    let mut os = part_path(dest).into_os_string();
+    os.push(".meta");
+    std::path::PathBuf::from(os)
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
+struct PartialIdentity {
+    file_id: String,
+    expected_size: u64,
+}
+
+fn parse_content_range(value: &str) -> Result<(u64, u64)> {
+    let value = value
+        .strip_prefix("bytes ")
+        .ok_or_else(|| anyhow!("invalid Content-Range unit: '{value}'"))?;
+    let (bounds, _) = value
+        .split_once('/')
+        .ok_or_else(|| anyhow!("invalid Content-Range: '{value}'"))?;
+    let (start, end) = bounds
+        .split_once('-')
+        .ok_or_else(|| anyhow!("invalid Content-Range bounds: '{bounds}'"))?;
+    let start = start
+        .parse::<u64>()
+        .with_context(|| format!("invalid Content-Range start: '{start}'"))?;
+    let end = end
+        .parse::<u64>()
+        .with_context(|| format!("invalid Content-Range end: '{end}'"))?;
+    if end < start {
+        return Err(anyhow!(
+            "invalid Content-Range bounds: end {end} precedes start {start}"
+        ));
+    }
+    Ok((start, end))
+}
+
+/// Prepare a resumable sidecar that is owned by exactly one remote file.
+///
+/// Unknown or mismatched sidecars are never deleted: `.part` and
+/// `.part.meta` are ordinary names a user may already own. Automatic callers
+/// can select another destination, while an explicit destination gets a clear
+/// conflict instead of silent local data loss.
+pub(crate) fn prepare_partial_download(
+    dest: &Path,
+    file_id: &str,
+    expected_size: u64,
+) -> Result<(std::path::PathBuf, u64)> {
+    let part = part_path(dest);
+    let identity_path = part_identity_path(dest);
+    let wanted = PartialIdentity {
+        file_id: file_id.to_string(),
+        expected_size,
+    };
+    let part_metadata = match fs::symlink_metadata(&part) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() {
+                return Err(anyhow!(
+                    "partial download path '{}' is not a regular file; move or remove it first",
+                    part.display()
+                ));
+            }
+            Some(metadata)
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("cannot inspect partial download '{}'", part.display()));
+        }
+    };
+
+    let identity = match fs::symlink_metadata(&identity_path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() {
+                return Err(anyhow!(
+                    "partial download identity '{}' is not a regular file; move or remove it first",
+                    identity_path.display()
+                ));
+            }
+            let raw = fs::read(&identity_path).with_context(|| {
+                format!(
+                    "cannot read partial download identity '{}'",
+                    identity_path.display()
+                )
+            })?;
+            Some(
+                serde_json::from_slice::<PartialIdentity>(&raw).with_context(|| {
+                    format!(
+                        "partial download identity '{}' is malformed; move or remove it first",
+                        identity_path.display()
+                    )
+                })?,
+            )
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "cannot inspect partial download identity '{}'",
+                    identity_path.display()
+                )
+            });
+        }
+    };
+
+    match identity {
+        Some(existing) if existing != wanted => {
+            return Err(anyhow!(
+                "partial download '{}' belongs to remote file '{}' (expected '{}'); move or remove its .part/.meta files first",
+                part.display(),
+                existing.file_id,
+                file_id
+            ));
+        }
+        Some(_) => {}
+        None if part_metadata.is_some() => {
+            return Err(anyhow!(
+                "partial download '{}' has no valid identity; move or remove it first",
+                part.display()
+            ));
+        }
+        None => {
+            let encoded = serde_json::to_vec(&wanted)
+                .context("failed to encode partial download identity")?;
+            let mut identity_file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&identity_path)
+                .with_context(|| {
+                    format!(
+                        "cannot claim partial download identity '{}'",
+                        identity_path.display()
+                    )
+                })?;
+            if let Err(e) = identity_file.write_all(&encoded) {
+                drop(identity_file);
+                let _ = fs::remove_file(&identity_path);
+                return Err(e).with_context(|| {
+                    format!(
+                        "cannot write partial download identity '{}'",
+                        identity_path.display()
+                    )
+                });
+            }
+        }
+    }
+
+    let size = part_metadata.map(|metadata| metadata.len()).unwrap_or(0);
+    if expected_size > 0 && size > expected_size {
+        return Err(anyhow!(
+            "partial download '{}' is larger than the expected {} bytes; move or remove it first",
+            part.display(),
+            expected_size
+        ));
+    }
+    Ok((part, size))
+}
+
+/// Move a complete partial into place and remove its resumable identity.
+pub(crate) fn finish_partial_download(dest: &Path, part: &Path) -> Result<()> {
+    let identity_path = part_identity_path(dest);
+    match fs::rename(part, dest) {
+        Ok(()) => {}
+        Err(first) if dest.exists() => {
+            fs::remove_file(dest).with_context(|| {
+                format!("cannot replace existing download '{}'", dest.display())
+            })?;
+            fs::rename(part, dest).with_context(|| {
+                format!(
+                    "downloaded but could not move '{}' into place after: {}",
+                    part.display(),
+                    first
+                )
+            })?;
+        }
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "downloaded but could not move '{}' into place",
+                    part.display()
+                )
+            });
+        }
+    }
+
+    match fs::remove_file(&identity_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e).with_context(|| {
+            format!(
+                "cannot remove partial download identity '{}'",
+                identity_path.display()
+            )
+        }),
+    }
 }
 
 impl PikPak {
@@ -65,7 +264,19 @@ impl PikPak {
         }
 
         let start_offset = if status == reqwest::StatusCode::PARTIAL_CONTENT {
-            existing_size
+            let value = response
+                .headers()
+                .get(reqwest::header::CONTENT_RANGE)
+                .ok_or_else(|| anyhow!("partial download response is missing Content-Range"))?
+                .to_str()
+                .context("partial download Content-Range is not valid text")?;
+            let (actual_start, _) = parse_content_range(value)?;
+            if actual_start != existing_size {
+                return Err(anyhow!(
+                    "partial download started at byte {actual_start}, expected {existing_size}"
+                ));
+            }
+            actual_start
         } else {
             0
         };
@@ -80,14 +291,11 @@ impl PikPak {
             .to_string();
         let total_size = info.file_size();
 
-        // The finished name is only ever a verified complete file; partial
-        // data lives in a .part sidecar, so an unrelated same-named local
-        // file can never be mistaken for a resumable partial.
-        let existing_size = dest.metadata().map(|m| m.len()).unwrap_or(0);
-        if total_size > 0 && existing_size == total_size {
-            return Ok(existing_size);
+        let (part, initial_part_size) = prepare_partial_download(dest, file_id, total_size)?;
+        if total_size > 0 && initial_part_size == total_size {
+            finish_partial_download(dest, &part)?;
+            return Ok(total_size);
         }
-        let part = part_path(dest);
 
         let mut renewed = false;
         let written = loop {
@@ -132,12 +340,7 @@ impl PikPak {
             }
         };
 
-        fs::rename(&part, dest).with_context(|| {
-            format!(
-                "downloaded but could not move '{}' into place",
-                part.display()
-            )
-        })?;
+        finish_partial_download(dest, &part)?;
         Ok(written)
     }
 
@@ -265,12 +468,6 @@ impl PikPak {
                         // the whole body and serialize every worker.
                         let msg = rx.lock().unwrap_or_else(|e| e.into_inner()).recv();
                         let Ok((entry, dest)) = msg else { break };
-                        let local_size = dest.metadata().map(|m| m.len()).unwrap_or(0);
-                        if local_size > 0 && local_size == entry.size {
-                            println!("  skipping '{}' (already complete)", dest.display());
-                            ok.fetch_add(1, Ordering::Relaxed);
-                            continue;
-                        }
                         println!("  {}", dest.display());
                         match self.download_to(&entry.id, &dest) {
                             Ok(_) => {
@@ -303,5 +500,82 @@ impl PikPak {
         }
 
         Ok((total_ok, total_failed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("pikpaktui-{label}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn unowned_partial_is_never_deleted_or_claimed() {
+        let dir = temp_dir("unowned-partial");
+        let dest = dir.join("movie");
+        let part = part_path(&dest);
+        fs::write(&part, b"user data").unwrap();
+
+        let err = prepare_partial_download(&dest, "remote", 100).unwrap_err();
+
+        assert!(format!("{err:#}").contains("has no valid identity"));
+        assert_eq!(fs::read(&part).unwrap(), b"user data");
+        assert!(!part_identity_path(&dest).exists());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn non_file_identity_cannot_cause_partial_deletion() {
+        let dir = temp_dir("identity-directory");
+        let dest = dir.join("movie");
+        let part = part_path(&dest);
+        let identity = part_identity_path(&dest);
+        fs::write(&part, b"user data").unwrap();
+        fs::create_dir(&identity).unwrap();
+
+        let err = prepare_partial_download(&dest, "remote", 100).unwrap_err();
+
+        assert!(format!("{err:#}").contains("is not a regular file"));
+        assert_eq!(fs::read(&part).unwrap(), b"user data");
+        assert!(identity.is_dir());
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn content_range_must_report_the_requested_start() {
+        assert_eq!(parse_content_range("bytes 42-99/100").unwrap(), (42, 99));
+        assert!(parse_content_range("items 42-99/100").is_err());
+        assert!(parse_content_range("bytes 100-42/101").is_err());
+        assert!(parse_content_range("bytes nope-99/100").is_err());
+    }
+
+    #[test]
+    fn failed_final_move_keeps_partial_identity_for_retry() {
+        let dir = temp_dir("partial-finalize");
+        let dest = dir.join("occupied");
+        fs::create_dir(&dest).unwrap();
+        let (part, _) = prepare_partial_download(&dest, "file-id", 5).unwrap();
+        fs::write(&part, b"hello").unwrap();
+        let identity = part_identity_path(&dest);
+
+        let result = finish_partial_download(&dest, &part);
+
+        assert!(result.is_err());
+        assert!(part.exists(), "complete partial should remain retryable");
+        assert!(
+            identity.exists(),
+            "partial identity should remain for retry"
+        );
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/pikpak/files.rs
+++ b/src/pikpak/files.rs
@@ -22,9 +22,7 @@ impl PikPak {
             if let Some(ref pt) = page_token {
                 rb = rb.query(&[("page_token", pt.as_str())]);
             }
-            rb = self.authed_headers(rb);
-
-            let response = rb.send().context("ls request failed")?;
+            let response = self.send_authed("ls", rb)?;
             let payload: DriveListResponse = json_or_api_error(response, "ls")?;
             let next = payload.next_page_token.filter(|t| !t.is_empty());
 
@@ -49,20 +47,21 @@ impl PikPak {
     /// folder appearing in every argument of a batch command) only hit the API once.
     /// TUI code that needs a fresh listing should call `ls()` directly.
     pub fn ls_cached(&self, parent_id: &str) -> Result<Vec<Entry>> {
-        if let Some(cached) = self
-            .ls_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(parent_id)
-        {
-            return Ok(cached.clone());
-        }
+        let generation = {
+            let cache = self.ls_cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(cached) = cache.entries.get(parent_id) {
+                return Ok(cached.clone());
+            }
+            cache.generation
+        };
         let entries = self.ls(parent_id)?;
         let result = entries.clone();
-        self.ls_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(parent_id.to_string(), entries);
+        let mut cache = self.ls_cache.lock().unwrap_or_else(|e| e.into_inner());
+        // A mutation may have invalidated the cache while the network request
+        // was in flight. Never publish that pre-mutation snapshot afterward.
+        if cache.generation == generation {
+            cache.entries.insert(parent_id.to_string(), entries);
+        }
         Ok(result)
     }
 
@@ -112,9 +111,7 @@ impl PikPak {
             if let Some(ref pt) = page_token {
                 rb = rb.query(&[("page_token", pt.as_str())]);
             }
-            rb = self.authed_headers(rb);
-
-            let response = rb.send().context("ls_trash request failed")?;
+            let response = self.send_authed("ls_trash", rb)?;
             let payload: DriveListResponse = json_or_api_error(response, "ls_trash")?;
             let next = payload.next_page_token.filter(|t| !t.is_empty());
 
@@ -147,10 +144,8 @@ impl PikPak {
             "to": { "parent_id": to_parent_id },
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("move request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("move", rb)?;
         ensure_success(response, "move")?;
         self.clear_ls_cache();
         Ok(())
@@ -165,10 +160,8 @@ impl PikPak {
             "to": { "parent_id": to_parent_id },
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("copy request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("copy", rb)?;
         ensure_success(response, "copy")?;
         self.clear_ls_cache();
         Ok(())
@@ -179,10 +172,8 @@ impl PikPak {
         let url = format!("{}/{}", self.drive_url("drive/v1/files"), file_id);
 
         let payload = serde_json::json!({ "name": new_name });
-        let mut rb = self.http.patch(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("rename request failed")?;
+        let rb = self.http.patch(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("rename", rb)?;
         ensure_success(response, "rename")?;
         self.clear_ls_cache();
         Ok(())
@@ -193,10 +184,8 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files:batchTrash");
 
         let payload = serde_json::json!({ "ids": ids });
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("remove request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("remove", rb)?;
         ensure_success(response, "remove")?;
         self.clear_ls_cache();
         Ok(())
@@ -207,10 +196,8 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files:batchDelete");
 
         let payload = serde_json::json!({ "ids": ids });
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("permanent delete request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("permanent delete", rb)?;
         ensure_success(response, "permanent delete")?;
         self.clear_ls_cache();
         Ok(())
@@ -222,10 +209,8 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("drive/v1/files/trash:empty");
 
-        let mut rb = self.http.patch(&url).bearer_auth(&token);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("empty trash request failed")?;
+        let rb = self.http.patch(&url).bearer_auth(&token);
+        let response = self.send_authed("empty trash", rb)?;
         ensure_success(response, "empty trash")?;
         self.clear_ls_cache();
         Ok(())
@@ -236,10 +221,8 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files:batchUntrash");
 
         let payload = serde_json::json!({ "ids": ids });
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("untrash request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("untrash", rb)?;
         ensure_success(response, "untrash")?;
         self.clear_ls_cache();
         Ok(())
@@ -255,10 +238,8 @@ impl PikPak {
             "name": name,
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("mkdir request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("mkdir", rb)?;
         let resp: DriveFileResponse = json_or_api_error(response, "mkdir")?;
         self.clear_ls_cache();
         Ok(resp.file.into_folder_entry())
@@ -268,35 +249,9 @@ impl PikPak {
         let token = self.access_token()?;
         let url = format!("{}/{}", self.drive_url("drive/v1/files"), file_id);
 
-        // Download-link fetches are the endpoint PikPak rate-guards with
-        // error_code 9 (riskLimited / captcha token expired). Reference
-        // clients refresh the captcha token for this exact action and retry
-        // once; do the same instead of surfacing an opaque 403.
-        for attempt in 0..2 {
-            let mut rb = self.http.get(&url).bearer_auth(&token);
-            rb = self.authed_headers(rb);
-
-            let response = rb.send().context("file_info request failed")?;
-            let status = response.status();
-            if status.is_success() {
-                return response.json().context("invalid file_info json");
-            }
-            let body = response.text().unwrap_or_default();
-            if attempt == 0
-                && super::api_error_code(&body) == Some(9)
-                && self
-                    .refresh_captcha_for_action(&format!("GET:/drive/v1/files/{file_id}"))
-                    .is_ok()
-            {
-                continue;
-            }
-            return Err(anyhow!(
-                "file_info failed ({}): {}",
-                status,
-                super::sanitize(&body)
-            ));
-        }
-        unreachable!("both file_info attempts returned early");
+        let rb = self.http.get(&url).bearer_auth(&token);
+        let response = self.send_authed("file_info", rb)?;
+        response.json().context("invalid file_info json")
     }
 
     pub fn star(&self, ids: &[&str]) -> Result<()> {
@@ -304,10 +259,8 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files:star");
 
         let payload = serde_json::json!({ "ids": ids });
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("star request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("star", rb)?;
         ensure_success(response, "star")?;
         self.clear_ls_cache();
         Ok(())
@@ -318,10 +271,8 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files:unstar");
 
         let payload = serde_json::json!({ "ids": ids });
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("unstar request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("unstar", rb)?;
         ensure_success(response, "unstar")?;
         self.clear_ls_cache();
         Ok(())
@@ -332,15 +283,13 @@ impl PikPak {
         let url = self.drive_url("drive/v1/files");
 
         let filters = r#"{"trashed":{"eq":false},"system_tag":{"in":"STAR"}}"#;
-        let mut rb = self.http.get(&url).bearer_auth(&token).query(&[
+        let rb = self.http.get(&url).bearer_auth(&token).query(&[
             ("parent_id", "*"),
             ("limit", &limit.to_string()),
             ("filters", filters),
             ("thumbnail_size", self.thumbnail_size.as_str()),
         ]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("starred list request failed")?;
+        let response = self.send_authed("starred list", rb)?;
         let payload: DriveListResponse = json_or_api_error(response, "starred list")?;
         let entries = payload
             .files

--- a/src/pikpak/mod.rs
+++ b/src/pikpak/mod.rs
@@ -11,7 +11,9 @@ mod share;
 mod upload;
 
 use auth::{CaptchaInitResponse, SigninResponse};
+#[cfg(test)]
 pub(crate) use download::part_path;
+pub(crate) use download::{finish_partial_download, prepare_partial_download};
 pub use file_info::FileInfoResponse;
 pub use models::{Entry, EntryKind, SessionToken};
 pub use responses::{
@@ -52,6 +54,12 @@ const CAPTCHA_SALTS: &[&str] = &[
     "KJE2oveZ34du/g1tiimm",
 ];
 
+#[derive(Default)]
+struct LsCache {
+    generation: u64,
+    entries: HashMap<String, Vec<Entry>>,
+}
+
 pub struct PikPak {
     pub(crate) http: reqwest::blocking::Client,
     drive_base_url: String,
@@ -62,9 +70,19 @@ pub struct PikPak {
     device_id: String,
     /// Refreshed lazily during `&self` drive calls, hence the Mutex.
     captcha_token: Mutex<String>,
+    captcha_expires_at_unix: Mutex<i64>,
+    /// Serializes action-captcha refreshes. Reactive retries keep this held
+    /// through the retry so another action cannot replace the fresh token.
+    captcha_refresh_lock: Mutex<()>,
+    /// Action that produced the current in-memory captcha token. This lets
+    /// concurrent failures for the same action reuse one refresh safely.
+    captcha_action: Mutex<String>,
     user_id: String,
     pub thumbnail_size: String,
-    ls_cache: Mutex<HashMap<String, Vec<Entry>>>,
+    ls_cache: Mutex<LsCache>,
+    /// Serializes session-file writes and load/modify/save updates in this
+    /// process. A disk lock below coordinates separate CLI/TUI processes.
+    session_lock: Mutex<()>,
     refresh_lock: Mutex<()>,
 }
 
@@ -88,9 +106,13 @@ impl PikPak {
             session_path: default_session_path()?,
             device_id: String::new(),
             captcha_token: Mutex::new(String::new()),
+            captcha_expires_at_unix: Mutex::new(0),
+            captcha_refresh_lock: Mutex::new(()),
+            captcha_action: Mutex::new(String::new()),
             user_id: String::new(),
             thumbnail_size: "SIZE_MEDIUM".to_string(),
-            ls_cache: Mutex::new(HashMap::new()),
+            ls_cache: Mutex::new(LsCache::default()),
+            session_lock: Mutex::new(()),
             refresh_lock: Mutex::new(()),
         };
         // Re-adopt the device identity from the saved session: without it,
@@ -99,6 +121,7 @@ impl PikPak {
         if let Ok(Some(session)) = client.load_session() {
             client.device_id = session.device_id;
             client.captcha_token = Mutex::new(session.captcha_token);
+            client.captcha_expires_at_unix = Mutex::new(session.captcha_expires_at_unix);
             client.user_id = session.user_id;
         }
         Ok(client)
@@ -116,6 +139,31 @@ impl PikPak {
     }
 
     fn save_session(&self, token: &SessionToken) -> Result<()> {
+        let _guard = self.session_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _file_guard = self.lock_session_file()?;
+        self.save_session_unlocked(token)
+    }
+
+    fn lock_session_file(&self) -> Result<fs::File> {
+        if let Some(parent) = self.session_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create dir {}", parent.display()))?;
+        }
+        let lock_path = self.session_path.with_extension("lock");
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("failed to open session lock {}", lock_path.display()))?;
+        set_file_owner_only(&lock_path);
+        file.lock()
+            .with_context(|| format!("failed to lock session {}", lock_path.display()))?;
+        Ok(file)
+    }
+
+    fn save_session_unlocked(&self, token: &SessionToken) -> Result<()> {
         if let Some(parent) = self.session_path.parent() {
             fs::create_dir_all(parent)
                 .with_context(|| format!("failed to create dir {}", parent.display()))?;
@@ -127,6 +175,16 @@ impl PikPak {
         fs::rename(&tmp_path, &self.session_path)
             .with_context(|| format!("failed to rename session {}", self.session_path.display()))?;
         set_file_owner_only(&self.session_path);
+        Ok(())
+    }
+
+    fn update_session(&self, update: impl FnOnce(&mut SessionToken)) -> Result<()> {
+        let _guard = self.session_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _file_guard = self.lock_session_file()?;
+        if let Some(mut session) = self.load_session()? {
+            update(&mut session);
+            self.save_session_unlocked(&session)?;
+        }
         Ok(())
     }
 
@@ -148,6 +206,9 @@ impl PikPak {
         self.device_id = md5_hex(email);
 
         let captcha = self.init_captcha(email)?;
+        let captcha_expires_in =
+            i64::try_from(captcha.expires_in).context("captcha expires_in overflow")?;
+        let captcha_expires_at_unix = now_unix().saturating_add(captcha_expires_in);
         let login_captcha = captcha
             .captcha_token
             // An empty token would sail through and fail signin with an opaque
@@ -166,6 +227,10 @@ impl PikPak {
                 )
             })?;
         *self.captcha_token.lock().unwrap_or_else(|e| e.into_inner()) = login_captcha.clone();
+        *self
+            .captcha_expires_at_unix
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = captcha_expires_at_unix;
 
         let url = self.auth_url("v1/auth/signin");
         let payload = serde_json::json!({
@@ -206,6 +271,7 @@ impl PikPak {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
                 .clone(),
+            captcha_expires_at_unix,
             user_id: signin.sub,
         };
 
@@ -279,12 +345,24 @@ impl PikPak {
     /// Use the refresh_token to obtain a new access_token without requiring
     /// the user's password. Saves the updated session to disk and returns
     /// the new access_token.
-    fn refresh_session(&self, refresh_token: &str) -> Result<String> {
+    fn refresh_session(&self, _refresh_token_hint: &str) -> Result<String> {
+        // Hold both locks through the HTTP exchange. A second process then
+        // reloads the newly rotated refresh token instead of submitting the
+        // stale one it observed before waiting.
+        let _guard = self.session_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _file_guard = self.lock_session_file()?;
+        let mut session = self
+            .load_session()?
+            .ok_or_else(|| anyhow!("not logged in, please login first"))?;
+        if !session.is_expired(now_unix() + 300) {
+            return Ok(session.access_token);
+        }
+
         let url = self.auth_url("v1/auth/token");
 
         let payload = serde_json::json!({
             "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
+            "refresh_token": session.refresh_token.clone(),
             "client_id": self.client_id,
             "client_secret": self.client_secret,
         });
@@ -307,33 +385,77 @@ impl PikPak {
 
         let refreshed: SigninResponse = response.json().context("invalid token refresh json")?;
         let expires_in = i64::try_from(refreshed.expires_in).context("expires_in overflow")?;
+        let access_token = refreshed.access_token;
+        let refresh_token = refreshed.refresh_token;
+        let refreshed_user_id = refreshed.sub;
 
-        let token = SessionToken {
-            access_token: refreshed.access_token.clone(),
-            refresh_token: refreshed.refresh_token,
-            expires_at_unix: now_unix().saturating_add(expires_in),
-            device_id: self.device_id.clone(),
-            captcha_token: self
-                .captcha_token
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .clone(),
-            user_id: if refreshed.sub.is_empty() {
-                self.user_id.clone()
-            } else {
-                refreshed.sub
-            },
-        };
-        self.save_session(&token)?;
+        // Only token fields change; captcha/device fields remain the latest
+        // values loaded after acquiring the cross-process session lock.
+        session.access_token = access_token.clone();
+        session.refresh_token = refresh_token;
+        session.expires_at_unix = now_unix().saturating_add(expires_in);
+        if !self.device_id.is_empty() {
+            session.device_id.clone_from(&self.device_id);
+        }
+        if !refreshed_user_id.is_empty() {
+            session.user_id = refreshed_user_id;
+        }
+        self.save_session_unlocked(&session)?;
 
-        Ok(refreshed.access_token)
+        Ok(access_token)
     }
 
-    fn authed_headers(
+    fn request_action(&self, rb: &reqwest::blocking::RequestBuilder) -> Result<String> {
+        let request = rb
+            .try_clone()
+            .ok_or_else(|| anyhow!("cannot clone authenticated request"))?
+            .build()
+            .context("cannot inspect authenticated request")?;
+        Ok(format!("{}:{}", request.method(), request.url().path()))
+    }
+
+    fn captcha_snapshot(&self) -> (String, i64) {
+        let token = self
+            .captcha_token
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let expires_at = *self
+            .captcha_expires_at_unix
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        (token, expires_at)
+    }
+
+    fn captcha_needs_refresh(&self) -> bool {
+        let (token, expires_at) = self.captcha_snapshot();
+        if token.is_empty() {
+            !self.device_id.is_empty()
+        } else {
+            expires_at <= now_unix().saturating_add(30)
+        }
+    }
+
+    fn ensure_captcha_for_action(&self, action: &str) -> Result<()> {
+        if !self.captcha_needs_refresh() {
+            return Ok(());
+        }
+        let _guard = self
+            .captcha_refresh_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Another request may have refreshed while this one waited.
+        if self.captcha_needs_refresh() {
+            self.refresh_captcha_for_action_locked(action)
+                .with_context(|| format!("captcha refresh for {action} failed"))?;
+        }
+        Ok(())
+    }
+
+    fn attach_authed_headers(
         &self,
-        rb: reqwest::blocking::RequestBuilder,
-    ) -> reqwest::blocking::RequestBuilder {
-        let mut rb = rb;
+        mut rb: reqwest::blocking::RequestBuilder,
+    ) -> (reqwest::blocking::RequestBuilder, String) {
         if !self.device_id.is_empty() {
             rb = rb.header("x-device-id", &self.device_id);
         }
@@ -343,9 +465,71 @@ impl PikPak {
             .unwrap_or_else(|e| e.into_inner())
             .clone();
         if !captcha.is_empty() {
-            rb = rb.header("x-captcha-token", captcha);
+            rb = rb.header("x-captcha-token", &captcha);
         }
-        rb
+        (rb, captcha)
+    }
+
+    fn send_authed(
+        &self,
+        op: &str,
+        rb: reqwest::blocking::RequestBuilder,
+    ) -> Result<reqwest::blocking::Response> {
+        let action = self.request_action(&rb)?;
+        let retry = rb
+            .try_clone()
+            .ok_or_else(|| anyhow!("cannot clone {op} request for captcha retry"))?;
+
+        self.ensure_captcha_for_action(&action)?;
+        let (first, used_captcha) = self.attach_authed_headers(rb);
+        let response = first
+            .send()
+            .with_context(|| format!("{op} request failed"))?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+        let body = response.text().unwrap_or_default();
+        if !api_error_requires_captcha_refresh(&body) {
+            return Err(anyhow!("{} failed ({}): {}", op, status, sanitize(&body)));
+        }
+
+        let _guard = self
+            .captcha_refresh_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let current_captcha = self
+            .captcha_token
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let current_action = self
+            .captcha_action
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let current_expiry = *self
+            .captcha_expires_at_unix
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let same_action_was_refreshed = current_captcha != used_captcha
+            && current_action == action
+            && current_expiry > now_unix().saturating_add(30);
+        if !same_action_was_refreshed {
+            self.refresh_captcha_for_action_locked(&action)
+                .with_context(|| format!("captcha refresh for {action} failed"))?;
+        }
+
+        let (retry, _) = self.attach_authed_headers(retry);
+        let response = retry
+            .send()
+            .with_context(|| format!("{op} request failed"))?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response);
+        }
+        let body = response.text().unwrap_or_default();
+        Err(anyhow!("{} failed ({}): {}", op, status, sanitize(&body)))
     }
 
     /// The salted MD5 chain reference clients compute for captcha refresh:
@@ -365,7 +549,7 @@ impl PikPak {
     /// Refresh the captcha token for one drive action ("METHOD:/path").
     /// Reference clients do this reactively when the API answers error_code 9
     /// (riskLimited); the new token is kept for subsequent calls.
-    fn refresh_captcha_for_action(&self, action: &str) -> Result<()> {
+    fn refresh_captcha_for_action_locked(&self, action: &str) -> Result<()> {
         let token = self.access_token()?;
         let url = self.auth_url("v1/shield/captcha/init");
         let timestamp = (now_unix_millis()).to_string();
@@ -414,6 +598,9 @@ impl PikPak {
             ));
         }
         let captcha: CaptchaInitResponse = response.json().context("invalid captcha json")?;
+        let expires_in =
+            i64::try_from(captcha.expires_in).context("captcha expires_in overflow")?;
+        let expires_at_unix = now_unix().saturating_add(expires_in);
         let new_token = captcha
             .captcha_token
             .filter(|t| !t.is_empty())
@@ -426,11 +613,20 @@ impl PikPak {
             })?;
 
         *self.captcha_token.lock().unwrap_or_else(|e| e.into_inner()) = new_token.clone();
-        // Persist so the next process starts with a live token.
-        if let Ok(Some(mut session)) = self.load_session() {
+        *self
+            .captcha_expires_at_unix
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = expires_at_unix;
+        *self
+            .captcha_action
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = action.to_string();
+        // Persist with one load/modify/save lock so an overlapping access-token
+        // refresh cannot be overwritten by this captcha update.
+        self.update_session(|session| {
             session.captcha_token = new_token;
-            let _ = self.save_session(&session);
-        }
+            session.captcha_expires_at_unix = expires_at_unix;
+        })?;
         Ok(())
     }
 
@@ -446,10 +642,9 @@ impl PikPak {
     /// resolution. Mutations call this on success so later path lookups see the
     /// new tree instead of a stale snapshot.
     fn clear_ls_cache(&self) {
-        self.ls_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clear();
+        let mut cache = self.ls_cache.lock().unwrap_or_else(|e| e.into_inner());
+        cache.generation = cache.generation.wrapping_add(1);
+        cache.entries.clear();
     }
 
     pub fn http(&self) -> &reqwest::blocking::Client {
@@ -460,13 +655,11 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("drive/v1/events");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token).query(&[
+        let rb = self.http.get(&url).bearer_auth(&token).query(&[
             ("thumbnail_size", self.thumbnail_size.as_str()),
             ("limit", &limit.to_string()),
         ]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("events request failed")?;
+        let response = self.send_authed("events", rb)?;
         json_or_api_error(response, "events")
     }
 }
@@ -560,21 +753,65 @@ fn now_unix_millis() -> i64 {
         .unwrap_or(0)
 }
 
-/// Pull PikPak's `error_code` out of an error body, if it is one.
-pub(super) fn api_error_code(body: &str) -> Option<i64> {
-    serde_json::from_str::<serde_json::Value>(body)
-        .ok()?
-        .get("error_code")?
-        .as_i64()
+/// PikPak reuses numeric error code 9 for unrelated business failures. Only
+/// the documented captcha/risk reasons may refresh and replay a request.
+fn api_error_requires_captcha_refresh(body: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    if value.get("error_code").and_then(|code| code.as_i64()) != Some(9) {
+        return false;
+    }
+    ["error", "reason", "error_description"]
+        .into_iter()
+        .filter_map(|field| value.get(field).and_then(|value| value.as_str()))
+        .any(|reason| {
+            reason.eq_ignore_ascii_case("captcha_invalid")
+                || reason.eq_ignore_ascii_case("risklimited")
+                || reason.eq_ignore_ascii_case("risk_limited")
+        })
 }
 
-/// Sanitize a filename from an API response to prevent path traversal.
+/// Sanitize an API-provided filename for a single portable path component.
 pub(crate) fn sanitize_filename(name: &str) -> String {
-    let cleaned = name.replace(['/', '\\'], "_").replace("..", "_");
-    // On Windows "C:evil" is drive-relative: Path::join replaces the base
-    // path entirely, so the file lands outside the download directory.
-    #[cfg(windows)]
-    let cleaned = cleaned.replace(':', "_");
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*') {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect();
+    let cleaned = cleaned.replace("..", "_");
+    let cleaned = cleaned.trim_end_matches([' ', '.']);
+    let mut cleaned = if cleaned.is_empty() {
+        "_".to_string()
+    } else {
+        cleaned.to_string()
+    };
+
+    let stem = cleaned
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    let reserved = matches!(
+        stem.as_str(),
+        "CON" | "CONIN$" | "CONOUT$" | "PRN" | "AUX" | "NUL"
+    ) || stem
+        .strip_prefix("COM")
+        .or_else(|| stem.strip_prefix("LPT"))
+        .is_some_and(|n| {
+            matches!(
+                n,
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+            )
+        });
+    if reserved {
+        cleaned.insert(0, '_');
+    }
     cleaned
 }
 
@@ -590,11 +827,13 @@ pub(crate) fn unique_local_name(
 ) -> String {
     fn reserve(taken: &mut std::collections::HashSet<String>, cand: &str) -> bool {
         let sidecar = format!("{cand}.part");
-        if taken.contains(cand) || taken.contains(&sidecar) {
+        let identity = format!("{sidecar}.meta");
+        if taken.contains(cand) || taken.contains(&sidecar) || taken.contains(&identity) {
             return false;
         }
         taken.insert(cand.to_string());
         taken.insert(sidecar);
+        taken.insert(identity);
         true
     }
 
@@ -634,6 +873,59 @@ fn md5_hex(input: &str) -> String {
         write!(hex, "{:02x}", b).unwrap();
     }
     hex
+}
+
+#[cfg(test)]
+mod filename_safety_tests {
+    use super::{sanitize_filename, unique_local_name};
+    use std::collections::HashSet;
+
+    #[test]
+    fn sanitize_filename_replaces_windows_illegal_and_control_characters() {
+        assert_eq!(
+            sanitize_filename("a<b>c:d\"e/f\\g|h?i*j\u{1f}.txt"),
+            "a_b_c_d_e_f_g_h_i_j_.txt"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_removes_windows_trailing_dots_and_spaces() {
+        assert_eq!(sanitize_filename("report. "), "report");
+        assert_eq!(sanitize_filename("..."), "_");
+    }
+
+    #[test]
+    fn sanitize_filename_escapes_windows_reserved_device_stems() {
+        for name in [
+            "CON",
+            "con.txt",
+            "CONIN$",
+            "conout$.log",
+            "PRN",
+            "AUX.log",
+            "NUL",
+            "COM1",
+            "com¹.txt",
+            "LPT²",
+            "lpt9.bin",
+        ] {
+            assert!(
+                sanitize_filename(name).starts_with('_'),
+                "{name} remained a reserved device path"
+            );
+        }
+        assert_eq!(sanitize_filename("com10.txt"), "com10.txt");
+    }
+
+    #[test]
+    fn unique_name_reserves_partial_identity_sidecar() {
+        let mut taken = HashSet::new();
+        assert_eq!(unique_local_name(&mut taken, "movie.mkv"), "movie.mkv");
+        assert_eq!(
+            unique_local_name(&mut taken, "movie.mkv.part.meta"),
+            "movie.mkv.part (1).meta"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -684,11 +976,16 @@ mod unique_name_tests {
 mod tests {
     use super::drive::DriveListResponse;
     use super::*;
-    use std::collections::HashMap;
     use std::io::Write as _;
     use std::net::TcpListener;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+
+    type PaginatedGetServer = (
+        String,
+        Arc<Mutex<Vec<Option<String>>>>,
+        std::thread::JoinHandle<()>,
+    );
 
     struct MockDownloadServer {
         base_url: String,
@@ -706,9 +1003,13 @@ mod tests {
             session_path,
             device_id: String::new(),
             captcha_token: Mutex::new(String::new()),
+            captcha_expires_at_unix: Mutex::new(0),
+            captcha_refresh_lock: Mutex::new(()),
+            captcha_action: Mutex::new(String::new()),
             user_id: String::new(),
             thumbnail_size: "SIZE_MEDIUM".to_string(),
-            ls_cache: Mutex::new(HashMap::new()),
+            ls_cache: Mutex::new(LsCache::default()),
+            session_lock: Mutex::new(()),
             refresh_lock: Mutex::new(()),
         };
         client
@@ -769,7 +1070,16 @@ mod tests {
                     });
 
                     if !ignore_range && let Some(start) = range_start {
-                        write_response(&mut stream, 206, "Partial Content", &content[start..]);
+                        let end = content.len().saturating_sub(1);
+                        let content_range =
+                            format!("Content-Range: bytes {start}-{end}/{}\r\n", content.len());
+                        write_response_with_headers(
+                            &mut stream,
+                            206,
+                            "Partial Content",
+                            &content[start..],
+                            &content_range,
+                        );
                     } else {
                         write_response(&mut stream, 200, "OK", content);
                     }
@@ -787,8 +1097,18 @@ mod tests {
     }
 
     fn write_response(stream: &mut std::net::TcpStream, code: u16, reason: &str, body: &[u8]) {
+        write_response_with_headers(stream, code, reason, body, "");
+    }
+
+    fn write_response_with_headers(
+        stream: &mut std::net::TcpStream,
+        code: u16,
+        reason: &str,
+        body: &[u8],
+        extra_headers: &str,
+    ) {
         let header = format!(
-            "HTTP/1.1 {code} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 {code} {reason}\r\nContent-Length: {}\r\n{extra_headers}Connection: close\r\n\r\n",
             body.len()
         );
         stream.write_all(header.as_bytes()).unwrap();
@@ -813,6 +1133,264 @@ mod tests {
             }
         });
         (base_url, handle)
+    }
+
+    fn start_paginated_get_server(responses: Vec<&'static str>) -> PaginatedGetServer {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requested_tokens = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requested_tokens);
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            let mut served = 0usize;
+            while served < responses.len() && std::time::Instant::now() < deadline {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(e) => panic!("share detail server accept failed: {e}"),
+                };
+                let mut buf = [0u8; 4096];
+                let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]);
+                let target = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or_default();
+                let page_token = target.split_once('?').and_then(|(_, query)| {
+                    query
+                        .split('&')
+                        .find_map(|pair| pair.strip_prefix("page_token=").map(str::to_string))
+                });
+                captured
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(page_token);
+                write_response(&mut stream, 200, "OK", responses[served].as_bytes());
+                served += 1;
+            }
+        });
+        (base_url, requested_tokens, handle)
+    }
+
+    fn start_captcha_refresh_server()
+    -> (String, Arc<Mutex<Vec<String>>>, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requests);
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 8192];
+                        let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
+                        let request = String::from_utf8_lossy(&buf[..n]).into_owned();
+                        let first_line = request.lines().next().unwrap_or_default().to_string();
+                        captured
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(request);
+
+                        if first_line.starts_with("POST /v1/shield/captcha/init") {
+                            write_response(
+                                &mut stream,
+                                200,
+                                "OK",
+                                br#"{"captcha_token":"fresh-captcha","expires_in":300}"#,
+                            );
+                        } else if first_line.starts_with("GET /drive/v1/about") {
+                            write_response(
+                                &mut stream,
+                                200,
+                                "OK",
+                                br#"{"quota":{"limit":"100","usage":"1"}}"#,
+                            );
+                        } else {
+                            write_response(&mut stream, 404, "Not Found", b"not found");
+                        }
+
+                        if captured.lock().unwrap_or_else(|e| e.into_inner()).len() == 2 {
+                            break;
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(e) => panic!("captcha server accept failed: {e}"),
+                }
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    #[derive(Clone, Copy)]
+    enum ReactiveCaptchaMode {
+        RetrySucceeds,
+        RefreshFails,
+        RetryStillLimited,
+    }
+
+    fn start_reactive_captcha_server(
+        mode: ReactiveCaptchaMode,
+    ) -> (String, Arc<Mutex<Vec<String>>>, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&requests);
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let mut about_attempts = 0usize;
+            while std::time::Instant::now() < deadline {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(e) => panic!("reactive captcha server accept failed: {e}"),
+                };
+                let mut buf = [0u8; 8192];
+                let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
+                let request = String::from_utf8_lossy(&buf[..n]).into_owned();
+                let first_line = request.lines().next().unwrap_or_default().to_string();
+                captured
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .push(request);
+
+                if first_line.starts_with("GET /drive/v1/about") {
+                    about_attempts += 1;
+                    if about_attempts == 1 || matches!(mode, ReactiveCaptchaMode::RetryStillLimited)
+                    {
+                        write_response(
+                            &mut stream,
+                            403,
+                            "Forbidden",
+                            br#"{"error_code":9,"error":"riskLimited"}"#,
+                        );
+                    } else {
+                        write_response(
+                            &mut stream,
+                            200,
+                            "OK",
+                            br#"{"quota":{"limit":"100","usage":"1"}}"#,
+                        );
+                    }
+                } else if first_line.starts_with("POST /v1/shield/captcha/init") {
+                    assert!(
+                        captured
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .last()
+                            .unwrap()
+                            .contains(r#""action":"GET:/drive/v1/about""#)
+                    );
+                    if matches!(mode, ReactiveCaptchaMode::RefreshFails) {
+                        write_response(
+                            &mut stream,
+                            500,
+                            "Internal Server Error",
+                            br#"{"error":"refresh failed"}"#,
+                        );
+                        break;
+                    }
+                    write_response(
+                        &mut stream,
+                        200,
+                        "OK",
+                        br#"{"captcha_token":"fresh-captcha","expires_in":300}"#,
+                    );
+                } else {
+                    write_response(&mut stream, 404, "Not Found", b"not found");
+                }
+
+                let request_count = captured.lock().unwrap_or_else(|e| e.into_inner()).len();
+                let expected = match mode {
+                    ReactiveCaptchaMode::RefreshFails => 2,
+                    ReactiveCaptchaMode::RetrySucceeds | ReactiveCaptchaMode::RetryStillLimited => {
+                        3
+                    }
+                };
+                if request_count >= expected {
+                    break;
+                }
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    fn start_concurrent_captcha_server(
+        guarded_requests: usize,
+    ) -> (String, Arc<AtomicUsize>, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let refresh_count = Arc::new(AtomicUsize::new(0));
+        let refreshes = Arc::clone(&refresh_count);
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+            let mut pending_refreshes: Vec<std::net::TcpStream> = Vec::new();
+            let mut first_refresh_at: Option<std::time::Instant> = None;
+            let mut about_count = 0usize;
+
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut buf = [0u8; 8192];
+                        let n = std::io::Read::read(&mut stream, &mut buf).unwrap_or(0);
+                        let request = String::from_utf8_lossy(&buf[..n]);
+                        let first_line = request.lines().next().unwrap_or_default();
+                        if first_line.starts_with("POST /v1/shield/captcha/init") {
+                            refreshes.fetch_add(1, Ordering::SeqCst);
+                            first_refresh_at.get_or_insert_with(std::time::Instant::now);
+                            pending_refreshes.push(stream);
+                        } else if first_line.starts_with("GET /drive/v1/about") {
+                            about_count += 1;
+                            write_response(
+                                &mut stream,
+                                200,
+                                "OK",
+                                br#"{"quota":{"limit":"100","usage":"1"}}"#,
+                            );
+                        } else {
+                            write_response(&mut stream, 404, "Not Found", b"not found");
+                        }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(2));
+                    }
+                    Err(e) => panic!("concurrent captcha server accept failed: {e}"),
+                }
+
+                let held_long_enough = first_refresh_at.is_some_and(|started| {
+                    started.elapsed() >= std::time::Duration::from_millis(250)
+                });
+                if !pending_refreshes.is_empty()
+                    && (pending_refreshes.len() >= guarded_requests || held_long_enough)
+                {
+                    for mut stream in pending_refreshes.drain(..) {
+                        write_response(
+                            &mut stream,
+                            200,
+                            "OK",
+                            br#"{"captcha_token":"fresh-captcha","expires_in":300}"#,
+                        );
+                    }
+                }
+                if about_count == guarded_requests && pending_refreshes.is_empty() {
+                    break;
+                }
+            }
+        });
+        (base_url, refresh_count, handle)
     }
 
     /// Server that answers drive listings (counting how many it serves) and
@@ -844,6 +1422,62 @@ mod tests {
         (base_url, list_hits, handle)
     }
 
+    fn start_blocking_listing_server() -> (
+        String,
+        std::sync::mpsc::Receiver<()>,
+        std::sync::mpsc::Sender<()>,
+        Arc<AtomicUsize>,
+        std::thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let list_hits = Arc::new(AtomicUsize::new(0));
+        let hits = Arc::clone(&list_hits);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            let (mut first, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = std::io::Read::read(&mut first, &mut buf);
+            hits.fetch_add(1, Ordering::SeqCst);
+            started_tx.send(()).unwrap();
+            release_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .unwrap();
+            write_response(
+                &mut first,
+                200,
+                "OK",
+                br#"{"files":[{"id":"old","name":"old","kind":"drive#folder"}]}"#,
+            );
+
+            listener.set_nonblocking(true).unwrap();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut second, _)) => {
+                        let _ = std::io::Read::read(&mut second, &mut buf);
+                        hits.fetch_add(1, Ordering::SeqCst);
+                        write_response(
+                            &mut second,
+                            200,
+                            "OK",
+                            br#"{"files":[{"id":"new","name":"new","kind":"drive#folder"}]}"#,
+                        );
+                        break;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                    Err(e) => panic!("listing server accept failed: {e}"),
+                }
+            }
+        });
+
+        (base_url, started_rx, release_tx, list_hits, handle)
+    }
+
     #[test]
     fn token_expiry_check() {
         let token = SessionToken {
@@ -854,6 +1488,23 @@ mod tests {
         };
         assert!(!token.is_expired(99));
         assert!(token.is_expired(100));
+    }
+
+    #[test]
+    fn session_token_preserves_captcha_expiry() {
+        let token: SessionToken = serde_json::from_str(
+            r#"{
+                "access_token":"a",
+                "refresh_token":"r",
+                "expires_at_unix":200,
+                "captcha_token":"captcha",
+                "captcha_expires_at_unix":123
+            }"#,
+        )
+        .unwrap();
+
+        let encoded = serde_json::to_value(token).unwrap();
+        assert_eq!(encoded["captcha_expires_at_unix"], 123);
     }
 
     #[test]
@@ -873,6 +1524,14 @@ mod tests {
         assert_eq!(resp.access_token, "new_access");
         assert_eq!(resp.refresh_token, "new_refresh");
         assert_eq!(resp.expires_in, 7200);
+    }
+
+    #[test]
+    fn captcha_response_exposes_its_expiry() {
+        let response: CaptchaInitResponse =
+            serde_json::from_str(r#"{"captcha_token":"captcha","expires_in":300}"#).unwrap();
+
+        assert_eq!(response.expires_in, 300);
     }
 
     #[test]
@@ -922,6 +1581,148 @@ mod tests {
     }
 
     #[test]
+    fn share_detail_follows_token_across_empty_intermediate_page() {
+        let (base_url, requested_tokens, handle) = start_paginated_get_server(vec![
+            r#"{
+                "files":[{"id":"first","name":"first","kind":"drive#file"}],
+                "next_page_token":"empty-page"
+            }"#,
+            r#"{"files":[],"next_page_token":"last-page"}"#,
+            r#"{"files":[{"id":"last","name":"last","kind":"drive#file"}]}"#,
+        ]);
+        let dir = temp_test_dir("share-detail-empty-page");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let entries = client.share_detail("share", "", "pass").unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "last"]
+        );
+        assert_eq!(
+            *requested_tokens.lock().unwrap_or_else(|e| e.into_inner()),
+            vec![
+                None,
+                Some("empty-page".to_string()),
+                Some("last-page".to_string())
+            ]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn share_detail_stops_before_reusing_any_seen_page_token() {
+        let (base_url, requested_tokens, handle) = start_paginated_get_server(vec![
+            r#"{
+                "files":[{"id":"root","name":"root","kind":"drive#file"}],
+                "next_page_token":"page-a"
+            }"#,
+            r#"{
+                "files":[{"id":"a","name":"a","kind":"drive#file"}],
+                "next_page_token":"page-b"
+            }"#,
+            r#"{
+                "files":[{"id":"b","name":"b","kind":"drive#file"}],
+                "next_page_token":"page-a"
+            }"#,
+        ]);
+        let dir = temp_test_dir("share-detail-token-cycle");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let result = client.share_detail("share", "", "pass");
+        handle.join().unwrap();
+
+        let entries = result.unwrap();
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["root", "a", "b"]
+        );
+        assert_eq!(
+            *requested_tokens.lock().unwrap_or_else(|e| e.into_inner()),
+            vec![None, Some("page-a".to_string()), Some("page-b".to_string())]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn list_shares_follows_token_across_empty_intermediate_page() {
+        let (base_url, requested_tokens, handle) = start_paginated_get_server(vec![
+            r#"{
+                "data":[{"share_id":"first","share_url":"https://example/first"}],
+                "next_page_token":"empty-page"
+            }"#,
+            r#"{"data":[],"next_page_token":"last-page"}"#,
+            r#"{"data":[{"share_id":"last","share_url":"https://example/last"}]}"#,
+        ]);
+        let dir = temp_test_dir("list-shares-empty-page");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let shares = client.list_shares().unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(
+            shares
+                .iter()
+                .map(|share| share.share_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "last"]
+        );
+        assert_eq!(
+            *requested_tokens.lock().unwrap_or_else(|e| e.into_inner()),
+            vec![
+                None,
+                Some("empty-page".to_string()),
+                Some("last-page".to_string())
+            ]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn list_shares_stops_before_reusing_any_seen_page_token() {
+        let (base_url, requested_tokens, handle) = start_paginated_get_server(vec![
+            r#"{
+                "data":[{"share_id":"root","share_url":"https://example/root"}],
+                "next_page_token":"page-a"
+            }"#,
+            r#"{
+                "data":[{"share_id":"a","share_url":"https://example/a"}],
+                "next_page_token":"page-b"
+            }"#,
+            r#"{
+                "data":[{"share_id":"b","share_url":"https://example/b"}],
+                "next_page_token":"page-a"
+            }"#,
+        ]);
+        let dir = temp_test_dir("list-shares-token-cycle");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let result = client.list_shares();
+        handle.join().unwrap();
+
+        let shares = result.unwrap();
+        assert_eq!(
+            shares
+                .iter()
+                .map(|share| share.share_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["root", "a", "b"]
+        );
+        assert_eq!(
+            *requested_tokens.lock().unwrap_or_else(|e| e.into_inner()),
+            vec![None, Some("page-a".to_string()), Some("page-b".to_string())]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn drive_list_response_tolerates_non_numeric_size() {
         // A single entry with an empty/garbage size must not abort the whole
         // listing — it should fall back to size 0.
@@ -940,18 +1741,20 @@ mod tests {
     }
 
     #[test]
-    fn download_to_skips_already_complete_file() {
-        let server = start_mock_download_server(b"hello", false, 1);
+    fn download_to_replaces_unverified_same_size_destination() {
+        // Matching length alone cannot prove that an existing destination is
+        // the requested cloud file.
+        let server = start_mock_download_server(b"hello", false, 2);
         let dir = temp_test_dir("download-complete");
         let dest = dir.join("file.bin");
-        std::fs::write(&dest, b"hello").unwrap();
+        std::fs::write(&dest, b"WRONG").unwrap();
         let client = test_client(server.base_url, dir.join("session.json"));
 
         let total = client.download_to("file", &dest).unwrap();
 
         assert_eq!(total, 5);
         assert_eq!(std::fs::read(&dest).unwrap(), b"hello");
-        assert_eq!(server.download_hits.load(Ordering::SeqCst), 0);
+        assert_eq!(server.download_hits.load(Ordering::SeqCst), 1);
         server.handle.join().unwrap();
         std::fs::remove_dir_all(dir).unwrap();
     }
@@ -980,6 +1783,10 @@ mod tests {
         let dir = temp_test_dir("download-part-resume");
         let dest = dir.join("file.bin");
         std::fs::write(part_path(&dest), b"he").unwrap();
+        let mut identity_path = part_path(&dest).into_os_string();
+        identity_path.push(".meta");
+        let identity_path = std::path::PathBuf::from(identity_path);
+        std::fs::write(&identity_path, r#"{"file_id":"file","expected_size":5}"#).unwrap();
         let client = test_client(server.base_url, dir.join("session.json"));
 
         let total = client.download_to("file", &dest).unwrap();
@@ -987,6 +1794,39 @@ mod tests {
         assert_eq!(total, 5);
         assert_eq!(std::fs::read(&dest).unwrap(), b"hello");
         assert!(!part_path(&dest).exists(), "sidecar must be renamed away");
+        assert!(
+            !identity_path.exists(),
+            "completed download must remove partial identity"
+        );
+        server.handle.join().unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn download_to_preserves_partial_owned_by_different_file() {
+        // A prior download with the same destination must neither contribute
+        // its prefix nor be silently deleted.
+        let server = start_mock_download_server(b"hello", false, 1);
+        let dir = temp_test_dir("download-part-identity");
+        let dest = dir.join("file.bin");
+        std::fs::write(part_path(&dest), b"XX").unwrap();
+        let mut identity_path = part_path(&dest).into_os_string();
+        identity_path.push(".meta");
+        let identity_path = std::path::PathBuf::from(identity_path);
+        let identity = r#"{"file_id":"other-file","expected_size":5}"#;
+        std::fs::write(&identity_path, identity).unwrap();
+        let client = test_client(server.base_url, dir.join("session.json"));
+
+        let err = client.download_to("file", &dest).unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("belongs to remote file 'other-file'"),
+            "got: {err:#}"
+        );
+        assert_eq!(std::fs::read(part_path(&dest)).unwrap(), b"XX");
+        assert_eq!(std::fs::read_to_string(identity_path).unwrap(), identity);
+        assert!(!dest.exists());
+        assert_eq!(server.download_hits.load(Ordering::SeqCst), 0);
         server.handle.join().unwrap();
         std::fs::remove_dir_all(dir).unwrap();
     }
@@ -1087,6 +1927,378 @@ mod tests {
     }
 
     #[test]
+    fn file_info_surfaces_captcha_refresh_failure() {
+        let body = br#"{"error_code":9,"error":"riskLimited"}"#.to_vec();
+        let (base_url, handle) = start_canned_server(403, "Forbidden", body);
+        let dir = temp_test_dir("file-info-captcha-refresh");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let err = client.file_info("FID").unwrap_err();
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("captcha refresh"), "got: {msg}");
+        handle.join().unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn business_error_code_nine_is_not_replayed_as_captcha() {
+        let body =
+            br#"{"error_code":9,"error":"file_move_or_copy_to_cur","error_description":"same parent"}"#
+                .to_vec();
+        let (base_url, handle) = start_canned_server(400, "Bad Request", body);
+        let dir = temp_test_dir("business-code-nine");
+        let client = test_client(base_url, dir.join("session.json"));
+
+        let err = client.file_info("FID").unwrap_err();
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("file_move_or_copy_to_cur"), "got: {msg}");
+        assert!(!msg.contains("captcha refresh"), "got: {msg}");
+        handle.join().unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn expired_captcha_is_refreshed_before_guarded_request() {
+        let (base_url, requests, handle) = start_captcha_refresh_server();
+        let dir = temp_test_dir("proactive-captcha-refresh");
+        let session_path = dir.join("session.json");
+        let mut client = test_client(base_url.clone(), session_path);
+        client.auth_base_url = base_url;
+        *client
+            .captcha_token
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = "stale-captcha".to_string();
+        client
+            .save_session(&SessionToken {
+                access_token: "test-access".into(),
+                refresh_token: "test-refresh".into(),
+                expires_at_unix: now_unix() + 3600,
+                device_id: "device".into(),
+                captcha_token: "stale-captcha".into(),
+                captcha_expires_at_unix: now_unix() - 1,
+                user_id: "user".into(),
+            })
+            .unwrap();
+
+        client.quota().unwrap();
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap_or_else(|e| e.into_inner());
+
+        assert_eq!(requests.len(), 2, "{requests:#?}");
+        assert!(
+            requests[0].starts_with("POST /v1/shield/captcha/init"),
+            "{requests:#?}"
+        );
+        assert!(
+            requests[1].starts_with("GET /drive/v1/about"),
+            "{requests:#?}"
+        );
+        assert!(
+            requests[1]
+                .to_ascii_lowercase()
+                .contains("x-captcha-token: fresh-captcha"),
+            "{requests:#?}"
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    fn captcha_test_client(
+        base_url: String,
+        session_path: std::path::PathBuf,
+        captcha_expiry: i64,
+    ) -> PikPak {
+        let mut client = test_client(base_url.clone(), session_path);
+        client.auth_base_url = base_url;
+        client.device_id = "device".into();
+        client.user_id = "user".into();
+        *client
+            .captcha_token
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = "stale-captcha".into();
+        *client
+            .captcha_expires_at_unix
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = captcha_expiry;
+        client
+            .save_session(&SessionToken {
+                access_token: "test-access".into(),
+                refresh_token: "test-refresh".into(),
+                expires_at_unix: now_unix() + 3600,
+                device_id: "device".into(),
+                captcha_token: "stale-captcha".into(),
+                captcha_expires_at_unix: captcha_expiry,
+                user_id: "user".into(),
+            })
+            .unwrap();
+        client
+    }
+
+    #[test]
+    fn generic_authed_endpoint_refreshes_code_nine_and_retries_once() {
+        let (base_url, requests, handle) =
+            start_reactive_captcha_server(ReactiveCaptchaMode::RetrySucceeds);
+        let dir = temp_test_dir("generic-reactive-captcha");
+        let client = captcha_test_client(
+            base_url,
+            dir.join("session.json"),
+            now_unix().saturating_add(300),
+        );
+
+        let result = client.quota();
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            result.is_ok(),
+            "unexpected error: {:#}",
+            result.unwrap_err()
+        );
+        assert_eq!(requests.len(), 3, "{requests:#?}");
+        assert!(requests[0].starts_with("GET /drive/v1/about"));
+        assert!(requests[1].starts_with("POST /v1/shield/captcha/init"));
+        assert!(requests[2].starts_with("GET /drive/v1/about"));
+        assert!(
+            requests[2]
+                .to_ascii_lowercase()
+                .contains("x-captcha-token: fresh-captcha")
+        );
+        drop(requests);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn generic_authed_endpoint_surfaces_captcha_refresh_failure() {
+        let (base_url, requests, handle) =
+            start_reactive_captcha_server(ReactiveCaptchaMode::RefreshFails);
+        let dir = temp_test_dir("generic-captcha-refresh-failure");
+        let client = captcha_test_client(
+            base_url,
+            dir.join("session.json"),
+            now_unix().saturating_add(300),
+        );
+
+        let result = client.quota();
+
+        handle.join().unwrap();
+        let err = result.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("captcha refresh failed"),
+            "unexpected error: {err:#}"
+        );
+        assert_eq!(requests.lock().unwrap_or_else(|e| e.into_inner()).len(), 2);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn generic_authed_endpoint_stops_after_second_code_nine() {
+        let (base_url, requests, handle) =
+            start_reactive_captcha_server(ReactiveCaptchaMode::RetryStillLimited);
+        let dir = temp_test_dir("generic-second-captcha-code-nine");
+        let client = captcha_test_client(
+            base_url,
+            dir.join("session.json"),
+            now_unix().saturating_add(300),
+        );
+
+        let result = client.quota();
+
+        handle.join().unwrap();
+        let err = result.unwrap_err();
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("quota failed (403 Forbidden)"),
+            "{message}"
+        );
+        assert!(message.contains("riskLimited"), "{message}");
+        assert_eq!(requests.lock().unwrap_or_else(|e| e.into_inner()).len(), 3);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn concurrent_expired_requests_share_one_proactive_captcha_refresh() {
+        const REQUESTS: usize = 4;
+        let (base_url, refresh_count, handle) = start_concurrent_captcha_server(REQUESTS);
+        let dir = temp_test_dir("concurrent-proactive-captcha");
+        let client = Arc::new(captcha_test_client(
+            base_url,
+            dir.join("session.json"),
+            now_unix().saturating_sub(1),
+        ));
+        let barrier = Arc::new(std::sync::Barrier::new(REQUESTS));
+        let mut threads = Vec::new();
+        for _ in 0..REQUESTS {
+            let client = Arc::clone(&client);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                client.quota()
+            }));
+        }
+
+        let results: Vec<_> = threads.into_iter().map(|t| t.join().unwrap()).collect();
+        handle.join().unwrap();
+
+        assert!(results.iter().all(Result::is_ok), "{results:#?}");
+        assert_eq!(refresh_count.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn empty_captcha_token_is_refreshed_before_authenticated_request() {
+        let (base_url, requests, handle) = start_captcha_refresh_server();
+        let dir = temp_test_dir("empty-proactive-captcha");
+        let session_path = dir.join("session.json");
+        let client = captcha_test_client(base_url, session_path, 0);
+        *client
+            .captcha_token
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = String::new();
+        client
+            .save_session(&SessionToken {
+                access_token: "test-access".into(),
+                refresh_token: "test-refresh".into(),
+                expires_at_unix: now_unix() + 3600,
+                device_id: "device".into(),
+                captcha_token: String::new(),
+                captcha_expires_at_unix: 0,
+                user_id: "user".into(),
+            })
+            .unwrap();
+
+        let result = client.quota();
+
+        handle.join().unwrap();
+        let requests = requests.lock().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            result.is_ok(),
+            "unexpected error: {:#}",
+            result.unwrap_err()
+        );
+        assert_eq!(requests.len(), 2, "{requests:#?}");
+        assert!(requests[0].starts_with("POST /v1/shield/captcha/init"));
+        assert!(requests[1].starts_with("GET /drive/v1/about"));
+        drop(requests);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn access_refresh_preserves_captcha_fields_under_session_lock() {
+        let body = br#"{
+            "access_token":"new-access",
+            "refresh_token":"new-refresh",
+            "expires_in":3600,
+            "sub":"user"
+        }"#
+        .to_vec();
+        let (base_url, handle) = start_canned_server(200, "OK", body);
+        let dir = temp_test_dir("access-captcha-session-race");
+        let session_path = dir.join("session.json");
+        let mut client = test_client(base_url.clone(), session_path);
+        client.auth_base_url = base_url;
+        client.device_id = "device".into();
+        client.user_id = "user".into();
+        let fresh_expiry = now_unix() + 300;
+        client
+            .save_session(&SessionToken {
+                access_token: "old-access".into(),
+                refresh_token: "old-refresh".into(),
+                expires_at_unix: now_unix() - 1,
+                device_id: "device".into(),
+                captcha_token: "new-captcha".into(),
+                captcha_expires_at_unix: fresh_expiry,
+                user_id: "user".into(),
+            })
+            .unwrap();
+
+        assert_eq!(client.refresh_session("old-refresh").unwrap(), "new-access");
+        handle.join().unwrap();
+        let saved = client.load_session().unwrap().unwrap();
+        assert_eq!(saved.access_token, "new-access");
+        assert_eq!(saved.refresh_token, "new-refresh");
+        assert_eq!(saved.captcha_token, "new-captcha");
+        assert_eq!(saved.captcha_expires_at_unix, fresh_expiry);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn separate_clients_honor_the_same_session_file_lock() {
+        let dir = temp_test_dir("cross-client-session-lock");
+        let session_path = dir.join("session.json");
+        let first = Arc::new(test_client(String::new(), session_path.clone()));
+        let second = Arc::new(test_client(String::new(), session_path));
+        first
+            .save_session(&SessionToken {
+                access_token: "before".into(),
+                refresh_token: "refresh".into(),
+                expires_at_unix: now_unix() + 3600,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let file_guard = first.lock_session_file().unwrap();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            ready_tx.send(()).unwrap();
+            let result = second.update_session(|session| {
+                session.access_token = "after".into();
+            });
+            done_tx.send(result).unwrap();
+        });
+
+        ready_rx.recv().unwrap();
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "a separate PikPak instance must wait for the disk lock"
+        );
+        drop(file_guard);
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        writer.join().unwrap();
+        assert_eq!(first.load_session().unwrap().unwrap().access_token, "after");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn concurrent_session_writes_do_not_race_shared_temp_file() {
+        const WRITERS: usize = 32;
+        let dir = temp_test_dir("concurrent-session-writes");
+        let client = Arc::new(test_client(String::new(), dir.join("shared-session.json")));
+        let barrier = Arc::new(std::sync::Barrier::new(WRITERS));
+        let mut threads = Vec::new();
+        for writer in 0..WRITERS {
+            let client = Arc::clone(&client);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                let token = SessionToken {
+                    access_token: format!("access-{writer}"),
+                    refresh_token: format!("refresh-{writer}"),
+                    expires_at_unix: now_unix() + 3600,
+                    ..Default::default()
+                };
+                barrier.wait();
+                client.save_session(&token)
+            }));
+        }
+
+        let results: Vec<_> = threads.into_iter().map(|t| t.join().unwrap()).collect();
+
+        assert!(
+            results.iter().all(Result::is_ok),
+            "concurrent save failed: {results:#?}"
+        );
+        let saved = client.load_session().unwrap().unwrap();
+        assert!(saved.access_token.starts_with("access-"));
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn offline_list_reports_invalid_json() {
         let (base_url, handle) = start_canned_server(200, "OK", b"<html>nope</html>".to_vec());
         let dir = temp_test_dir("offline-list-bad-json");
@@ -1166,6 +2378,30 @@ mod tests {
         assert_eq!(list_hits.load(Ordering::SeqCst), 2);
 
         handle.join().unwrap();
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn invalidation_during_inflight_listing_cannot_reinsert_stale_cache() {
+        let (base_url, started, release, list_hits, handle) = start_blocking_listing_server();
+        let dir = temp_test_dir("ls-cache-inflight-invalidation");
+        let client = Arc::new(test_client(base_url, dir.join("session.json")));
+        let requesting_client = Arc::clone(&client);
+
+        let request = std::thread::spawn(move || requesting_client.ls_cached("").unwrap());
+        started
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        client.clear_ls_cache();
+        release.send(()).unwrap();
+        let first = request.join().unwrap();
+        assert_eq!(first[0].name, "old");
+
+        let second = client.ls_cached("").unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(second[0].name, "new");
+        assert_eq!(list_hits.load(Ordering::SeqCst), 2);
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/src/pikpak/models.rs
+++ b/src/pikpak/models.rs
@@ -31,6 +31,10 @@ pub struct SessionToken {
     pub device_id: String,
     #[serde(default)]
     pub captcha_token: String,
+    /// Expiry of the action captcha token. Older session files omit this and
+    /// deserialize to zero, which intentionally forces a refresh before reuse.
+    #[serde(default)]
+    pub captcha_expires_at_unix: i64,
     #[serde(default)]
     pub user_id: String,
 }

--- a/src/pikpak/offline.rs
+++ b/src/pikpak/offline.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 
 use super::{
     OfflineListResponse, OfflineTask, OfflineTaskResponse, PikPak, ensure_success,
@@ -30,10 +30,8 @@ impl PikPak {
             payload["name"] = serde_json::json!(n);
         }
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("offline download request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("offline download", rb)?;
         json_or_api_error(response, "offline download")
     }
 
@@ -45,16 +43,14 @@ impl PikPak {
             "phase": { "in": phases.join(",") }
         });
 
-        let mut rb = self.http.get(&url).bearer_auth(&token).query(&[
+        let rb = self.http.get(&url).bearer_auth(&token).query(&[
             ("type", "offline"),
             ("thumbnail_size", "SIZE_SMALL"),
             ("limit", &limit.to_string()),
             ("filters", &filters.to_string()),
             ("with", "reference_resource"),
         ]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("offline list request failed")?;
+        let response = self.send_authed("offline list", rb)?;
         json_or_api_error(response, "offline list")
     }
 
@@ -70,10 +66,8 @@ impl PikPak {
             "thumbnail_type": "FROM_HASH",
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("resource parse request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("resource parse", rb)?;
         json_or_api_error(response, "resource parse")
     }
 
@@ -82,14 +76,12 @@ impl PikPak {
         let token = self.access_token()?;
         let url = format!("{}/{}", self.drive_url("drive/v1/tasks"), task_id);
 
-        let mut rb = self
+        let rb = self
             .http
             .get(&url)
             .bearer_auth(&token)
             .query(&[("type", "offline"), ("checkPhase", "true")]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("task poll request failed")?;
+        let response = self.send_authed("task poll", rb)?;
         let value: serde_json::Value = json_or_api_error(response, "task poll")?;
         // Some deployments wrap the task, some return it bare.
         let task = if value.get("task").is_some() {
@@ -110,10 +102,8 @@ impl PikPak {
             "id": task_id,
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("offline task retry request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("offline task retry", rb)?;
         ensure_success(response, "offline task retry")
     }
 
@@ -131,9 +121,7 @@ impl PikPak {
         for (k, v) in &pairs {
             rb = rb.query(&[(k, v)]);
         }
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("delete tasks request failed")?;
+        let response = self.send_authed("delete tasks", rb)?;
         ensure_success(response, "delete tasks")
     }
 }

--- a/src/pikpak/responses.rs
+++ b/src/pikpak/responses.rs
@@ -72,8 +72,6 @@ pub struct ShareInfoResponse {
     pub share_status: String,
     #[serde(default)]
     pub pass_code_token: String,
-    #[serde(default)]
-    pub files: Vec<ShareEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -262,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn share_info_parses_files_and_status() {
+    fn share_info_parses_status_and_ignores_embedded_files() {
         let json = r#"{
             "share_status": "OK",
             "pass_code_token": "PCT123",
@@ -274,18 +272,15 @@ mod tests {
         let resp: ShareInfoResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.share_status, "OK");
         assert_eq!(resp.pass_code_token, "PCT123");
-        assert_eq!(resp.files.len(), 2);
-        assert_eq!(resp.files[1].name, "b.txt");
     }
 
     #[test]
     fn share_info_tolerates_missing_optional_fields() {
-        // A restricted share may omit pass_code_token and files.
+        // A restricted share may omit pass_code_token.
         let resp: ShareInfoResponse =
             serde_json::from_str(r#"{"share_status":"SENSITIVE_RESOURCE"}"#).unwrap();
         assert_eq!(resp.share_status, "SENSITIVE_RESOURCE");
         assert!(resp.pass_code_token.is_empty());
-        assert!(resp.files.is_empty());
     }
 
     #[test]

--- a/src/pikpak/share.rs
+++ b/src/pikpak/share.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result, anyhow};
+use std::collections::HashSet;
 
 use super::{
     CreateShareResponse, MyShare, PikPak, ShareEntry, ShareInfoResponse, ShareListResponse,
-    ensure_success, json_or_api_error, sanitize,
+    ensure_success, json_or_api_error,
 };
 
 impl PikPak {
@@ -10,23 +11,12 @@ impl PikPak {
         let token = self.access_token()?;
         let url = self.drive_url("drive/v1/share");
 
-        let mut rb = self.http.get(&url).bearer_auth(&token).query(&[
+        let rb = self.http.get(&url).bearer_auth(&token).query(&[
             ("share_id", share_id),
             ("pass_code", pass_code),
             ("thumbnail_size", "SIZE_MEDIUM"),
         ]);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("share info request failed")?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().unwrap_or_default();
-            return Err(anyhow!(
-                "share info failed ({}): {}",
-                status,
-                sanitize(&body)
-            ));
-        }
+        let response = self.send_authed("share info", rb)?;
 
         let info: ShareInfoResponse = response.json().context("invalid share info json")?;
         if info.share_status != "OK" {
@@ -55,23 +45,14 @@ impl PikPak {
             "to": { "parent_id": to_parent_id },
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("save share request failed")?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().unwrap_or_default();
-            if body.contains("file_restore_own") {
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        if let Err(e) = self.send_authed("save share", rb) {
+            if format!("{e:#}").contains("file_restore_own") {
                 return Err(anyhow!(
                     "cannot save: these files already belong to your account"
                 ));
             }
-            return Err(anyhow!(
-                "save share failed ({}): {}",
-                status,
-                sanitize(&body)
-            ));
+            return Err(e);
         }
         self.clear_ls_cache();
         Ok(())
@@ -93,10 +74,8 @@ impl PikPak {
             "pass_code_option": if need_password { "REQUIRED" } else { "NOT_REQUIRED" },
         });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("create share request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("create share", rb)?;
         json_or_api_error(response, "create share")
     }
 
@@ -114,6 +93,7 @@ impl PikPak {
 
         let mut entries: Vec<ShareEntry> = Vec::new();
         let mut page_token: Option<String> = None;
+        let mut seen_page_tokens = HashSet::new();
         loop {
             let mut rb = self.http.get(&url).bearer_auth(&token).query(&[
                 ("share_id", share_id),
@@ -125,16 +105,13 @@ impl PikPak {
             if let Some(ref pt) = page_token {
                 rb = rb.query(&[("page_token", pt.as_str())]);
             }
-            rb = self.authed_headers(rb);
-
-            let response = rb.send().context("share detail request failed")?;
+            let response = self.send_authed("share detail", rb)?;
             let resp: super::ShareDetailResponse = json_or_api_error(response, "share detail")?;
-            let got_any = !resp.files.is_empty();
             entries.extend(resp.files);
 
             match resp.next_page_token.filter(|t| !t.is_empty()) {
-                Some(t) if !got_any || page_token.as_deref() == Some(t.as_str()) => break,
-                Some(t) => page_token = Some(t),
+                Some(t) if seen_page_tokens.insert(t.clone()) => page_token = Some(t),
+                Some(_) => break,
                 None => break,
             }
         }
@@ -149,6 +126,7 @@ impl PikPak {
         // first 100.
         let mut shares: Vec<MyShare> = Vec::new();
         let mut page_token: Option<String> = None;
+        let mut seen_page_tokens = HashSet::new();
         loop {
             let mut rb = self
                 .http
@@ -158,16 +136,13 @@ impl PikPak {
             if let Some(ref pt) = page_token {
                 rb = rb.query(&[("page_token", pt.as_str())]);
             }
-            rb = self.authed_headers(rb);
-
-            let response = rb.send().context("list shares request failed")?;
+            let response = self.send_authed("list shares", rb)?;
             let resp: ShareListResponse = json_or_api_error(response, "list shares")?;
-            let got_any = !resp.data.is_empty();
             shares.extend(resp.data);
 
             match resp.next_page_token.filter(|t| !t.is_empty()) {
-                Some(t) if !got_any || page_token.as_deref() == Some(t.as_str()) => break,
-                Some(t) => page_token = Some(t),
+                Some(t) if seen_page_tokens.insert(t.clone()) => page_token = Some(t),
+                Some(_) => break,
                 None => break,
             }
         }
@@ -180,10 +155,8 @@ impl PikPak {
 
         let payload = serde_json::json!({ "ids": share_ids });
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-
-        let response = rb.send().context("delete shares request failed")?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("delete shares", rb)?;
         ensure_success(response, "delete shares")
     }
 }

--- a/src/pikpak/upload.rs
+++ b/src/pikpak/upload.rs
@@ -23,13 +23,21 @@ impl PikPak {
             .to_string_lossy()
             .to_string();
 
-        let meta = fs::metadata(local_path)
+        let meta = fs::symlink_metadata(local_path)
             .with_context(|| format!("cannot stat '{}'", local_path.display()))?;
+        if meta.file_type().is_symlink() {
+            return Err(anyhow!(
+                "refusing to upload symbolic link file '{}'",
+                local_path.display()
+            ));
+        }
+        if !meta.is_file() {
+            return Err(anyhow!("not a regular file: '{}'", local_path.display()));
+        }
         let file_size = meta.len();
 
         let hash = pikpak_hash(local_path)?;
 
-        let token = self.access_token()?;
         let url = self.drive_url("drive/v1/files");
         let mut payload = serde_json::json!({
             "kind": "drive#file",
@@ -43,19 +51,9 @@ impl PikPak {
             payload["parent_id"] = serde_json::json!(pid);
         }
 
-        let mut rb = self.http.post(&url).bearer_auth(&token).json(&payload);
-        rb = self.authed_headers(rb);
-        let response = rb.send().context("upload init request failed")?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().unwrap_or_default();
-            return Err(anyhow!(
-                "upload init failed ({}): {}",
-                status,
-                sanitize(&body)
-            ));
-        }
-
+        let token = self.access_token()?;
+        let rb = self.http.post(&url).bearer_auth(&token).json(&payload);
+        let response = self.send_authed("upload init", rb)?;
         let init: UploadInitResponse = response.json().context("invalid upload init json")?;
 
         // Instant completion (hash dedup): the server already had this content,
@@ -106,6 +104,17 @@ impl PikPak {
     }
 
     pub fn upload_dir(&self, parent_id: &str, local_dir: &Path) -> Result<(usize, usize)> {
+        let local_meta = fs::symlink_metadata(local_dir)
+            .with_context(|| format!("cannot stat '{}'", local_dir.display()))?;
+        if local_meta.file_type().is_symlink() {
+            return Err(anyhow!(
+                "refusing to upload symbolic link directory '{}'",
+                local_dir.display()
+            ));
+        }
+        if !local_meta.is_dir() {
+            return Err(anyhow!("not a directory: '{}'", local_dir.display()));
+        }
         let name = local_dir
             .file_name()
             .ok_or_else(|| anyhow!("directory has no name"))?
@@ -121,7 +130,18 @@ impl PikPak {
             .with_context(|| format!("cannot read dir: {}", local_dir.display()))?;
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(e) => {
+                    eprintln!("  [error] cannot inspect '{}': {e}", path.display());
+                    failed += 1;
+                    continue;
+                }
+            };
+            if file_type.is_symlink() {
+                eprintln!("  [skip] symbolic link '{}'", path.display());
+                failed += 1;
+            } else if file_type.is_dir() {
                 let name = path.file_name().unwrap_or_default().to_string_lossy();
                 match self.mkdir(parent_id, &name) {
                     Ok(sub) => {
@@ -136,7 +156,7 @@ impl PikPak {
                         failed += Self::count_files_in(&path).max(1);
                     }
                 }
-            } else if path.is_file() {
+            } else if file_type.is_file() {
                 match self.upload_file(Some(parent_id), &path) {
                     Ok(_) => ok += 1,
                     Err(e) => {
@@ -153,15 +173,10 @@ impl PikPak {
         std::fs::read_dir(dir)
             .map(|rd| {
                 rd.flatten()
-                    .map(|e| {
-                        let p = e.path();
-                        if p.is_dir() {
-                            Self::count_files_in(&p)
-                        } else if p.is_file() {
-                            1
-                        } else {
-                            0
-                        }
+                    .map(|e| match e.file_type() {
+                        Ok(file_type) if file_type.is_dir() => Self::count_files_in(&e.path()),
+                        Ok(file_type) if file_type.is_file() => 1,
+                        _ => 0,
                     })
                     .sum()
             })
@@ -566,4 +581,255 @@ pub(super) struct ResumableParams {
     pub(super) bucket: Option<String>,
     #[serde(default)]
     pub(super) key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pikpak::SessionToken;
+    use std::io::Write as _;
+    use std::net::TcpListener;
+    use std::sync::Mutex;
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "pikpaktui-upload-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn upload_test_client(base_url: String, session_path: &Path) -> PikPak {
+        let mut client = PikPak::new().unwrap();
+        client.drive_base_url = base_url.clone();
+        client.auth_base_url = base_url;
+        client.session_path = session_path.to_path_buf();
+        client.device_id = "test-device".into();
+        client.user_id = "test-user".into();
+        client.captcha_token = Mutex::new("stale-captcha".into());
+        let captcha_expires_at_unix = crate::pikpak::now_unix() + 300;
+        client.captcha_expires_at_unix = Mutex::new(captcha_expires_at_unix);
+        client
+            .save_session(&SessionToken {
+                access_token: "test-access".into(),
+                refresh_token: "test-refresh".into(),
+                expires_at_unix: crate::pikpak::now_unix() + 3600,
+                device_id: "test-device".into(),
+                user_id: "test-user".into(),
+                captcha_token: "stale-captcha".into(),
+                captcha_expires_at_unix,
+            })
+            .unwrap();
+        client
+    }
+
+    fn write_response(stream: &mut std::net::TcpStream, code: u16, reason: &str, body: &[u8]) {
+        let header = format!(
+            "HTTP/1.1 {code} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(header.as_bytes()).unwrap();
+        stream.write_all(body).unwrap();
+    }
+
+    fn start_upload_captcha_server(
+        refresh_succeeds: bool,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+        let handle = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let mut request_index = 0usize;
+            while std::time::Instant::now() < deadline {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(e) => panic!("accept failed: {e}"),
+                };
+                let mut buf = [0u8; 8192];
+                let n = stream.read(&mut buf).unwrap();
+                let request = String::from_utf8_lossy(&buf[..n]);
+                request_index += 1;
+
+                match request_index {
+                    1 => {
+                        assert!(request.starts_with("POST /drive/v1/files "));
+                        write_response(
+                            &mut stream,
+                            400,
+                            "Bad Request",
+                            br#"{"error_code":9,"error":"riskLimited"}"#,
+                        );
+                    }
+                    2 => {
+                        assert!(request.starts_with("POST /v1/shield/captcha/init?"));
+                        assert!(
+                            request.contains(r#""action":"POST:/drive/v1/files""#),
+                            "wrong captcha action: {request}"
+                        );
+                        if refresh_succeeds {
+                            write_response(
+                                &mut stream,
+                                200,
+                                "OK",
+                                br#"{"captcha_token":"fresh-captcha","expires_in":300}"#,
+                            );
+                        } else {
+                            write_response(
+                                &mut stream,
+                                500,
+                                "Internal Server Error",
+                                br#"{"error":"refresh failed"}"#,
+                            );
+                            break;
+                        }
+                    }
+                    3 => {
+                        assert!(request.starts_with("POST /drive/v1/files "));
+                        assert!(
+                            request
+                                .to_ascii_lowercase()
+                                .contains("x-captcha-token: fresh-captcha"),
+                            "retry did not use refreshed captcha: {request}"
+                        );
+                        write_response(
+                            &mut stream,
+                            200,
+                            "OK",
+                            br#"{"file":{"phase":"PHASE_TYPE_COMPLETE"}}"#,
+                        );
+                        break;
+                    }
+                    _ => panic!("unexpected request: {request}"),
+                }
+            }
+        });
+
+        (base_url, handle)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn count_files_does_not_follow_directory_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("count-symlink");
+        let outside = temp_dir("count-symlink-outside");
+        fs::write(root.join("inside.txt"), b"inside").unwrap();
+        fs::write(outside.join("outside.txt"), b"outside").unwrap();
+        symlink(&outside, root.join("escape")).unwrap();
+
+        assert_eq!(PikPak::count_files_in(&root), 1);
+
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_upload_rejects_symlink_root_before_remote_request() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("root-symlink");
+        let target = root.join("target");
+        fs::create_dir(&target).unwrap();
+        let link = root.join("link");
+        symlink(&target, &link).unwrap();
+
+        let mut client = PikPak::new().unwrap();
+        client.session_path = root.join("missing-session.json");
+        let err = client.upload_dir("parent", &link).unwrap_err();
+
+        assert!(
+            err.to_string().contains("symbolic link"),
+            "unexpected error: {err:#}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_upload_rejects_symlink_before_remote_request() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("file-symlink");
+        let target = root.join("target.txt");
+        fs::write(&target, b"secret").unwrap();
+        let link = root.join("link.txt");
+        symlink(&target, &link).unwrap();
+
+        let mut client = PikPak::new().unwrap();
+        client.session_path = root.join("missing-session.json");
+        let err = client.upload_file(Some("parent"), &link).unwrap_err();
+
+        assert!(
+            err.to_string().contains("symbolic link"),
+            "unexpected error: {err:#}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_upload_skips_symlink_entry_as_one_failure() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_dir("entry-symlink");
+        let outside = temp_dir("entry-symlink-outside");
+        fs::write(outside.join("one.txt"), b"one").unwrap();
+        fs::write(outside.join("two.txt"), b"two").unwrap();
+        symlink(&outside, root.join("escape")).unwrap();
+
+        let mut client = PikPak::new().unwrap();
+        client.session_path = root.join("missing-session.json");
+        let result = client.upload_dir_inner("parent", &root).unwrap();
+
+        assert_eq!(result, (0, 1));
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_dir_all(outside).unwrap();
+    }
+
+    #[test]
+    fn upload_init_refreshes_captcha_code_nine_once_and_retries() {
+        let dir = temp_dir("captcha-retry");
+        let file = dir.join("file.txt");
+        fs::write(&file, b"hello").unwrap();
+        let (base_url, handle) = start_upload_captcha_server(true);
+        let client = upload_test_client(base_url, &dir.join("session.json"));
+
+        let result = client.upload_file(Some("parent"), &file);
+
+        handle.join().unwrap();
+        fs::remove_dir_all(dir).unwrap();
+        assert_eq!(result.unwrap(), ("file.txt".into(), true));
+    }
+
+    #[test]
+    fn upload_init_surfaces_captcha_refresh_failure() {
+        let dir = temp_dir("captcha-refresh-failure");
+        let file = dir.join("file.txt");
+        fs::write(&file, b"hello").unwrap();
+        let (base_url, handle) = start_upload_captcha_server(false);
+        let client = upload_test_client(base_url, &dir.join("session.json"));
+
+        let result = client.upload_file(Some("parent"), &file);
+
+        handle.join().unwrap();
+        fs::remove_dir_all(dir).unwrap();
+        let err = result.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("captcha refresh failed"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/src/tui/completion.rs
+++ b/src/tui/completion.rs
@@ -8,6 +8,7 @@ pub(super) struct PathInput {
     pub candidates: Vec<String>,
     pub candidate_idx: Option<usize>,
     pub completion_base: String,
+    pub pending_request_id: Option<u64>,
 }
 
 impl PathInput {
@@ -17,15 +18,45 @@ impl PathInput {
             candidates: Vec::new(),
             candidate_idx: None,
             completion_base: String::new(),
+            pending_request_id: None,
         }
     }
+
+    /// Mark one completion lookup as pending. Repeated Tab presses while that
+    /// lookup is in flight reuse no resources and therefore cannot create an
+    /// unbounded queue of network threads.
+    fn begin_completion_request(&mut self, request_id: u64) -> bool {
+        if self.pending_request_id.is_some() {
+            return false;
+        }
+        self.pending_request_id = Some(request_id);
+        true
+    }
+
+    pub(super) fn clear_completion(&mut self) {
+        self.candidates.clear();
+        self.candidate_idx = None;
+        self.completion_base.clear();
+    }
+}
+
+fn reserve_completion_request(
+    in_flight: &mut Option<u64>,
+    input: &mut PathInput,
+    request_id: u64,
+) -> bool {
+    if in_flight.is_some() || !input.begin_completion_request(request_id) {
+        return false;
+    }
+    *in_flight = Some(request_id);
+    true
 }
 
 impl App {
     /// Cycle already-known candidates synchronously; otherwise fetch them on
     /// a worker thread (resolve + ls block for a network round-trip) and
     /// apply through OpResult::PathCandidates when they arrive.
-    pub(super) fn tab_complete(&self, input: &mut PathInput) {
+    pub(super) fn tab_complete(&mut self, input: &mut PathInput) {
         if !input.candidates.is_empty() {
             let idx = match input.candidate_idx {
                 Some(i) => (i + 1) % input.candidates.len(),
@@ -40,42 +71,44 @@ impl App {
         }
 
         let (parent_path, prefix) = split_path_prefix(&input.value);
+        let completion_parent = completion_parent_path(&self.current_path_display(), &parent_path);
+        let request_id = self.next_async_request_id();
+        if !reserve_completion_request(&mut self.path_completion_in_flight, input, request_id) {
+            return;
+        }
         let value_snapshot = input.value.clone();
         let current_folder = self.current_folder_id.clone();
+        let folder_context = current_folder.clone();
         let client = std::sync::Arc::clone(&self.client);
         let tx = self.result_tx.clone();
 
         std::thread::spawn(move || {
-            let parent_id = if parent_path.is_empty() {
-                // Relative: use current folder
-                current_folder
-            } else {
-                match client.resolve_path(&parent_path) {
-                    Ok(id) => id,
-                    Err(_) => return,
-                }
-            };
+            let matches = (|| {
+                let parent_id = if parent_path.is_empty() {
+                    // Relative: use current folder
+                    current_folder
+                } else {
+                    client.resolve_path(&completion_parent).ok()?
+                };
 
-            let entries = match client.ls(&parent_id) {
-                Ok(e) => e,
-                Err(_) => return,
-            };
-
-            let prefix_lower = prefix.to_lowercase();
-            let matches: Vec<String> = entries
-                .iter()
-                .filter(|e| e.kind == EntryKind::Folder)
-                .filter(|e| e.name.to_lowercase().starts_with(&prefix_lower))
-                .map(|e| e.name.clone())
-                .collect();
-
-            if matches.is_empty() {
-                return;
-            }
+                let entries = client.ls(&parent_id).ok()?;
+                let prefix_lower = prefix.to_lowercase();
+                Some(
+                    entries
+                        .iter()
+                        .filter(|e| e.kind == EntryKind::Folder)
+                        .filter(|e| e.name.to_lowercase().starts_with(&prefix_lower))
+                        .map(|e| e.name.clone())
+                        .collect(),
+                )
+            })()
+            .unwrap_or_default();
 
             let _ = tx.send(super::OpResult::PathCandidates {
+                request_id,
                 value: value_snapshot,
-                parent: parent_path,
+                folder_context,
+                parent: completion_parent,
                 matches,
             });
         });
@@ -103,6 +136,24 @@ pub(super) fn apply_path_candidates(
     }
 }
 
+/// Consume a completion response only when it belongs to the currently
+/// pending request and both its text and navigation context are unchanged.
+/// A response for the matching request clears `pending_request_id` even when
+/// stale, allowing a fresh Tab request immediately.
+pub(super) fn path_candidate_result_matches(
+    input: &mut PathInput,
+    request_id: u64,
+    requested_value: &str,
+    current_folder_id: &str,
+    requested_folder_id: &str,
+) -> bool {
+    if input.pending_request_id != Some(request_id) {
+        return false;
+    }
+    input.pending_request_id = None;
+    input.value == requested_value && current_folder_id == requested_folder_id
+}
+
 fn join_completed(parent: &str, name: &str) -> String {
     if parent.is_empty() {
         format!("{}/", name)
@@ -110,6 +161,18 @@ fn join_completed(parent: &str, name: &str) -> String {
         format!("/{}/", name)
     } else {
         format!("{}/{}/", parent, name)
+    }
+}
+
+fn completion_parent_path(current_path: &str, typed_parent: &str) -> String {
+    if typed_parent.starts_with('/') {
+        typed_parent.to_string()
+    } else if typed_parent.is_empty() {
+        current_path.to_string()
+    } else if current_path == "/" {
+        format!("/{typed_parent}")
+    } else {
+        format!("{current_path}/{typed_parent}")
     }
 }
 
@@ -134,5 +197,126 @@ pub(super) fn split_path_prefix(input: &str) -> (String, String) {
         Some(("", name)) => ("/".to_string(), name.to_string()),
         Some((parent, name)) => (parent.to_string(), name.to_string()),
         None => (String::new(), input.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PathInput, completion_parent_path, join_completed, path_candidate_result_matches,
+        reserve_completion_request,
+    };
+
+    #[test]
+    fn relative_completion_parents_are_anchored_to_the_current_folder() {
+        let cases = [
+            ("/", "", "/"),
+            ("/", "nested", "/nested"),
+            ("/Movies", "", "/Movies"),
+            ("/Movies", "nested", "/Movies/nested"),
+            ("/Movies", "nested/deeper", "/Movies/nested/deeper"),
+            ("/Movies", "/Shared", "/Shared"),
+        ];
+
+        for (current_path, typed_parent, expected) in cases {
+            assert_eq!(
+                completion_parent_path(current_path, typed_parent),
+                expected,
+                "{current_path:?} + {typed_parent:?}"
+            );
+        }
+
+        let parent = completion_parent_path("/Movies", "nested");
+        assert_eq!(join_completed(&parent, "Sci-Fi"), "/Movies/nested/Sci-Fi/");
+    }
+
+    #[test]
+    fn one_pending_completion_blocks_duplicate_tab_requests() {
+        let mut input = PathInput::new();
+        input.value = "mov".to_string();
+
+        let first = 1;
+        assert!(input.begin_completion_request(first));
+        assert!(!input.begin_completion_request(2));
+        assert_eq!(input.pending_request_id, Some(first));
+    }
+
+    #[test]
+    fn editing_candidates_does_not_release_the_live_request() {
+        let mut input = PathInput::new();
+        input.value = "mov".to_string();
+
+        let first = 1;
+        assert!(input.begin_completion_request(first));
+        input.value.push('i');
+        input.clear_completion();
+
+        assert_eq!(input.pending_request_id, Some(first));
+        assert!(
+            !input.begin_completion_request(2),
+            "editing and pressing Tab again must not start a second live request"
+        );
+    }
+
+    #[test]
+    fn one_live_request_blocks_a_new_dialog_until_the_result_returns() {
+        let mut old_dialog = PathInput::new();
+        let mut new_dialog = PathInput::new();
+        let mut in_flight = None;
+
+        assert!(reserve_completion_request(
+            &mut in_flight,
+            &mut old_dialog,
+            10
+        ));
+        assert!(!reserve_completion_request(
+            &mut in_flight,
+            &mut new_dialog,
+            11
+        ));
+        in_flight = None;
+        assert!(reserve_completion_request(
+            &mut in_flight,
+            &mut new_dialog,
+            11
+        ));
+
+        assert!(!path_candidate_result_matches(
+            &mut new_dialog,
+            10,
+            "",
+            "folder-a",
+            "folder-a"
+        ));
+        assert_eq!(new_dialog.pending_request_id, Some(11));
+    }
+
+    #[test]
+    fn completion_result_requires_unchanged_value_and_folder_context() {
+        let mut input = PathInput::new();
+        input.value = "mov".to_string();
+        let request_id = 20;
+        assert!(input.begin_completion_request(request_id));
+
+        assert!(!path_candidate_result_matches(
+            &mut input, request_id, "mov", "folder-b", "folder-a"
+        ));
+        // The matching request completed even though its stale result was
+        // rejected, so the user can press Tab again immediately.
+        assert!(input.pending_request_id.is_none());
+
+        let mut edited_input = PathInput::new();
+        edited_input.value = "movies".to_string();
+        let request_id = 21;
+        assert!(edited_input.begin_completion_request(request_id));
+        edited_input.value.push('/');
+        assert!(!path_candidate_result_matches(
+            &mut edited_input,
+            request_id,
+            "movies",
+            "folder-a",
+            "folder-a"
+        ));
+        assert!(edited_input.pending_request_id.is_none());
     }
 }

--- a/src/tui/download.rs
+++ b/src/tui/download.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Read as _, Seek, SeekFrom, Write as _};
 use std::path::{Path, PathBuf};
@@ -70,8 +70,18 @@ pub struct DownloadState {
     /// its entry until the worker acknowledges with Stopped, so a quick
     /// pause/resume can't spawn a second worker on the same file.
     pub active_ids: HashSet<u64>,
+    /// Destinations owned by cancelled tasks whose worker has not stopped yet.
+    /// The visible task can disappear immediately, but its data/.part/.meta
+    /// name family must remain reserved until the worker acknowledges exit.
+    retired_destinations: HashMap<u64, PathBuf>,
     pub max_concurrent: usize,
     next_id: u64,
+}
+
+pub(super) fn destination_name_family(name: &str) -> [String; 3] {
+    let partial = format!("{name}.part");
+    let identity = format!("{partial}.meta");
+    [name.to_string(), partial, identity]
 }
 
 impl DownloadState {
@@ -83,6 +93,7 @@ impl DownloadState {
             msg_tx: tx,
             msg_rx: rx,
             active_ids: HashSet::new(),
+            retired_destinations: HashMap::new(),
             max_concurrent: max_concurrent.max(1),
             next_id: 0,
         }
@@ -100,6 +111,8 @@ impl DownloadState {
             t.id = i as u64;
         }
         self.next_id = tasks.len() as u64;
+        self.active_ids.clear();
+        self.retired_destinations.clear();
         self.tasks = tasks;
     }
 
@@ -116,14 +129,53 @@ impl DownloadState {
             .any(|t| matches!(t.status, TaskStatus::Downloading | TaskStatus::Pending))
     }
 
+    /// Remove a cancellable task without freeing a live worker's slot. The
+    /// worker may still be blocked in a network read; its eventual `Stopped`
+    /// message is the only safe point at which to remove the active id.
+    pub fn cancel_task(&mut self, index: usize) -> Option<String> {
+        let cancellable = self.tasks.get(index).is_some_and(|task| {
+            matches!(
+                task.status,
+                TaskStatus::Downloading | TaskStatus::Paused | TaskStatus::Pending
+            )
+        });
+        if !cancellable {
+            return None;
+        }
+
+        let task = self.tasks.remove(index);
+        task.cancel_flag.store(true, Ordering::Relaxed);
+        if self.active_ids.contains(&task.id) {
+            self.retired_destinations
+                .insert(task.id, task.dest_path.clone());
+        }
+        if self.selected >= self.tasks.len() && self.selected > 0 {
+            self.selected -= 1;
+        }
+        Some(task.name)
+    }
+
+    /// Reserve every path family still owned by a visible or detached worker.
+    /// A cancelled task is detached from `tasks` immediately for the UI, but
+    /// its worker may still be returning from a blocking network call.
+    pub(super) fn reserved_names_in(&self, directory: &Path) -> HashSet<String> {
+        self.tasks
+            .iter()
+            .map(|task| &task.dest_path)
+            .chain(self.retired_destinations.values())
+            .filter(|path| path.parent() == Some(directory))
+            .filter_map(|path| {
+                path.file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .flat_map(|name| destination_name_family(&name))
+            .collect()
+    }
+
     /// Start pending tasks up to max_concurrent slots.
     pub fn start_next(&mut self, client: &Arc<PikPak>) {
         loop {
-            let active = self
-                .tasks
-                .iter()
-                .filter(|t| t.status == TaskStatus::Downloading)
-                .count();
+            let active = self.active_ids.len();
             if active >= self.max_concurrent {
                 break;
             }
@@ -184,6 +236,7 @@ impl DownloadState {
                         logs.push(format!("Downloaded '{}'", task.name));
                     }
                     self.active_ids.remove(&id);
+                    self.retired_destinations.remove(&id);
                     self.start_next(client);
                 }
                 DownloadMsg::Failed { id, error } => {
@@ -192,10 +245,12 @@ impl DownloadState {
                         logs.push(format!("Download failed '{}': {}", task.name, error));
                     }
                     self.active_ids.remove(&id);
+                    self.retired_destinations.remove(&id);
                     self.start_next(client);
                 }
                 DownloadMsg::Stopped { id } => {
                     self.active_ids.remove(&id);
+                    self.retired_destinations.remove(&id);
                     self.start_next(client);
                 }
             }
@@ -226,26 +281,37 @@ fn download_worker(
     client: &PikPak,
     id: u64,
     file_id: &str,
-    dest: &PathBuf,
+    dest: &Path,
     msg_tx: &Sender<DownloadMsg>,
     cancel_flag: &Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
+    if cancel_flag.load(Ordering::Relaxed) {
+        let _ = msg_tx.send(DownloadMsg::Stopped { id });
+        return Ok(());
+    }
     let (mut url, total_size) = client.download_url(file_id)?;
 
     let _ = msg_tx.send(DownloadMsg::Started { id, total_size });
 
+    if cancel_flag.load(Ordering::Relaxed) {
+        let _ = msg_tx.send(DownloadMsg::Stopped { id });
+        return Ok(());
+    }
     if let Some(parent) = dest.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    // The finished name is only ever a verified complete file; partial data
-    // lives in a .part sidecar (shared scheme with the CLI download).
-    let existing_size = dest.metadata().map(|m| m.len()).unwrap_or(0);
-    if total_size > 0 && existing_size == total_size {
+    let (part, initial_part_size) =
+        crate::pikpak::prepare_partial_download(dest, file_id, total_size)?;
+    if cancel_flag.load(Ordering::Relaxed) {
+        let _ = msg_tx.send(DownloadMsg::Stopped { id });
+        return Ok(());
+    }
+    if total_size > 0 && initial_part_size == total_size {
+        crate::pikpak::finish_partial_download(dest, &part)?;
         let _ = msg_tx.send(DownloadMsg::Done { id });
         return Ok(());
     }
-    let part = crate::pikpak::part_path(dest);
 
     let mut renewed = false;
     let downloaded = loop {
@@ -275,7 +341,11 @@ fn download_worker(
         }
     };
 
-    fs::rename(&part, dest)?;
+    if cancel_flag.load(Ordering::Relaxed) {
+        let _ = msg_tx.send(DownloadMsg::Stopped { id });
+        return Ok(());
+    }
+    crate::pikpak::finish_partial_download(dest, &part)?;
     let _ = msg_tx.send(DownloadMsg::Progress {
         id,
         downloaded,
@@ -296,9 +366,15 @@ fn stream_attempt(
     msg_tx: &Sender<DownloadMsg>,
     cancel_flag: &Arc<AtomicBool>,
 ) -> anyhow::Result<Option<u64>> {
+    if cancel_flag.load(Ordering::Relaxed) {
+        return Ok(None);
+    }
     // Shared range/resume contract with the CLI download (see download_stream).
     let (response, start_offset) = client.download_stream(url, part_size)?;
 
+    if cancel_flag.load(Ordering::Relaxed) {
+        return Ok(None);
+    }
     let mut file = if start_offset > 0 {
         let mut f = fs::OpenOptions::new()
             .write(true)
@@ -507,5 +583,82 @@ mod tests {
 
         // No second worker: the task is left Pending, unspawned.
         assert_eq!(state.tasks[0].status, TaskStatus::Pending);
+    }
+
+    #[test]
+    fn live_paused_worker_still_consumes_concurrency_slot() {
+        let client = Arc::new(PikPak::new().unwrap());
+        let mut state = DownloadState::new(1);
+
+        let paused_id = state.alloc_id();
+        let mut paused = downloading_task(paused_id, "paused");
+        paused.status = TaskStatus::Paused;
+        state.tasks.push(paused);
+        state.active_ids.insert(paused_id);
+
+        let pending_id = state.alloc_id();
+        let mut pending = downloading_task(pending_id, "pending");
+        pending.status = TaskStatus::Pending;
+        state.tasks.push(pending);
+
+        state.start_next(&client);
+
+        assert_eq!(state.tasks[1].status, TaskStatus::Pending);
+        assert!(!state.active_ids.contains(&pending_id));
+    }
+
+    #[test]
+    fn cancelling_task_keeps_slot_until_live_worker_stops() {
+        let mut state = DownloadState::new(1);
+        let active_id = state.alloc_id();
+        state.tasks.push(downloading_task(active_id, "active"));
+        state.active_ids.insert(active_id);
+
+        assert_eq!(state.cancel_task(0).as_deref(), Some("active"));
+        assert!(state.tasks.is_empty());
+        assert!(
+            state.active_ids.contains(&active_id),
+            "a blocking worker must retain its concurrency slot until Stopped"
+        );
+    }
+
+    #[test]
+    fn cancelling_task_reserves_destination_until_worker_stops() {
+        let client = Arc::new(PikPak::new().unwrap());
+        let mut state = DownloadState::new(2);
+        let active_id = state.alloc_id();
+        let mut active = downloading_task(active_id, "movie.mkv");
+        active.dest_path = PathBuf::from("/downloads/movie.mkv");
+        state.tasks.push(active);
+        state.active_ids.insert(active_id);
+
+        assert_eq!(state.cancel_task(0).as_deref(), Some("movie.mkv"));
+        assert_eq!(
+            state.reserved_names_in(Path::new("/downloads")),
+            destination_name_family("movie.mkv").into_iter().collect(),
+            "a detached worker still owns its data, partial and identity names"
+        );
+
+        state
+            .msg_tx
+            .send(DownloadMsg::Stopped { id: active_id })
+            .unwrap();
+        state.poll(&client);
+        assert!(
+            state.reserved_names_in(Path::new("/downloads")).is_empty(),
+            "the reservation is released only after the worker acknowledges exit"
+        );
+    }
+
+    #[test]
+    fn existing_destination_reserves_data_partial_and_identity_names() {
+        assert_eq!(
+            destination_name_family("movie.mkv"),
+            [
+                "movie.mkv".to_string(),
+                "movie.mkv.part".to_string(),
+                "movie.mkv.part.meta".to_string(),
+            ]
+        );
     }
 }

--- a/src/tui/draw.rs
+++ b/src/tui/draw.rs
@@ -484,6 +484,7 @@ impl App {
                 info,
                 image,
                 has_thumbnail,
+                ..
             } if !self.trash_entries.is_empty() => {
                 self.draw_trash_view(
                     f,
@@ -1664,6 +1665,7 @@ impl App {
                 info,
                 image,
                 has_thumbnail,
+                ..
             } => {
                 self.draw_info_overlay(f, info, image.as_ref(), *has_thumbnail);
             }
@@ -2251,7 +2253,7 @@ impl App {
     pub(super) fn draw_help_sheet(&self, f: &mut Frame) {
         let term = f.area();
 
-        let sheet_w = term.width.saturating_sub(4).clamp(44, 92);
+        let sheet_w = help_sheet_width(term.width);
         let inner_w = sheet_w.saturating_sub(2) as usize;
         let show_art = inner_w >= 70;
 
@@ -2345,26 +2347,26 @@ impl App {
 
         type HelpGroupRef<'a> = (&'a str, &'a Vec<(&'a str, &'a str)>);
 
-        // <=3 sections: one column each. >3: first two share column 0.
-        let columns: Vec<Vec<HelpGroupRef<'_>>> = if sections.len() <= 3 {
-            sections
-                .iter()
-                .map(|(name, items)| vec![(*name, items)])
-                .collect()
-        } else {
-            let mut cols: Vec<Vec<HelpGroupRef<'_>>> = Vec::new();
-            cols.push(vec![
-                (sections[0].0, &sections[0].1),
-                (sections[1].0, &sections[1].1),
-            ]);
-            for s in &sections[2..] {
-                cols.push(vec![(s.0, &s.1)]);
-            }
-            cols
-        };
-
-        let col_count = columns.len();
-        let col_w = inner_w / col_count;
+        // Keep enough room for both the key and a useful description. On
+        // narrow terminals, stack sections instead of squeezing three
+        // columns until their contents overlap or collapse to ellipses.
+        let section_heights: Vec<usize> =
+            sections.iter().map(|(_, items)| 1 + items.len()).collect();
+        let col_count = help_column_count(inner_w, sections.len(), key_w);
+        let assignments = balanced_help_columns(&section_heights, col_count);
+        let columns: Vec<Vec<HelpGroupRef<'_>>> = assignments
+            .iter()
+            .map(|column| {
+                column
+                    .iter()
+                    .map(|&section_idx| {
+                        let (name, items) = &sections[section_idx];
+                        (*name, items)
+                    })
+                    .collect()
+            })
+            .collect();
+        let col_widths = help_column_widths(inner_w, col_count);
 
         let col_heights: Vec<usize> = columns
             .iter()
@@ -2458,52 +2460,69 @@ impl App {
         for row in 0..max_rows {
             let mut spans = Vec::new();
             for (ci, rows) in col_rows.iter().enumerate() {
+                let col_w = col_widths[ci];
                 let prefix = if ci == 0 { " " } else { "" };
                 if row < rows.len() {
                     match &rows[row] {
                         RowKind::Title(name) => {
-                            let w = col_w.saturating_sub(prefix.len());
+                            let prefix_w = unicode_width::UnicodeWidthStr::width(prefix).min(col_w);
+                            let w = col_w.saturating_sub(prefix_w);
                             spans.push(Span::styled(
-                                format!("{}{}", prefix, pad_to_width(name, w)),
+                                format!(
+                                    "{}{}",
+                                    pad_to_width(prefix, prefix_w),
+                                    pad_to_width(name, w)
+                                ),
                                 title_style,
                             ));
                         }
                         RowKind::Item(key, desc) => {
-                            let dw = col_w.saturating_sub(key_w + 1 + prefix.len());
-                            spans.push(Span::styled(
-                                format!("{}{} ", prefix, pad_to_width(key, key_w)),
-                                key_style,
-                            ));
-                            // Keep one gutter column so a truncated description
-                            // never touches the next column's key.
-                            spans.push(Span::styled(
-                                format!("{} ", pad_to_width(desc, dw.saturating_sub(1))),
-                                desc_style,
-                            ));
+                            let (key_part, desc_part) =
+                                help_item_parts(prefix, key, desc, key_w, col_w);
+                            spans.push(Span::styled(key_part, key_style));
+                            spans.push(Span::styled(desc_part, desc_style));
                         }
                         RowKind::Blank => {
-                            spans.push(Span::raw(format!("{:<width$}", "", width = col_w)));
+                            spans.push(Span::raw(" ".repeat(col_w)));
                         }
                     }
                 } else {
-                    spans.push(Span::raw(format!("{:<width$}", "", width = col_w)));
+                    spans.push(Span::raw(" ".repeat(col_w)));
                 }
             }
             lines.push(Line::from(spans));
         }
 
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            " Press any key to close",
-            Style::default().fg(Color::DarkGray),
-        )));
+
+        // The close hint owns the final interior row. The help body scrolls
+        // independently above it, so a short terminal never clips the only
+        // instruction that tells the user how to leave the overlay.
+        let interior_height = sheet_h.saturating_sub(2) as usize;
+        let body_height = interior_height.saturating_sub(1);
+        let max_scroll = lines.len().saturating_sub(body_height);
+        self.help_scroll_max.set(max_scroll);
+        let scroll = self.help_scroll.min(max_scroll);
+        let mut visible_lines: Vec<Line> =
+            lines.into_iter().skip(scroll).take(body_height).collect();
+        if interior_height > 0 {
+            let hint = if max_scroll > 0 {
+                " ↑/↓  Esc closes"
+            } else {
+                " Press any key to close"
+            };
+            visible_lines.push(Line::from(Span::styled(
+                hint,
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
 
         let (hp_bc, hp_tc) = if self.is_vibrant() {
             (Color::LightMagenta, Color::LightMagenta)
         } else {
             (Color::Cyan, Color::Cyan)
         };
-        let p = Paragraph::new(Text::from(lines)).block(
+        let p = Paragraph::new(Text::from(visible_lines)).block(
             self.styled_block()
                 .title(" Help ")
                 .title_style(Style::default().fg(hp_tc).add_modifier(Modifier::BOLD))
@@ -4125,6 +4144,98 @@ fn share_detail_lines(share: &crate::pikpak::MyShare, width: u16) -> Vec<Line<'s
     lines
 }
 
+/// Width of the help overlay, capped by the actual terminal. The previous
+/// minimum of 44 columns could produce a rectangle wider than a small terminal.
+fn help_sheet_width(terminal_width: u16) -> u16 {
+    terminal_width
+        .saturating_sub(4)
+        .clamp(44, 92)
+        .min(terminal_width)
+}
+
+/// Number of help columns that can preserve the key plus at least four
+/// display cells of description text. Keeping this floor modest also avoids
+/// turning a short, narrow terminal into one very tall clipped column.
+fn help_column_count(inner_width: usize, section_count: usize, key_width: usize) -> usize {
+    if section_count == 0 {
+        return 0;
+    }
+    let min_column_width = key_width + 2 + 4;
+    (inner_width / min_column_width).max(1).min(section_count)
+}
+
+fn help_column_widths(inner_width: usize, column_count: usize) -> Vec<usize> {
+    if column_count == 0 {
+        return Vec::new();
+    }
+    let base = inner_width / column_count;
+    let remainder = inner_width % column_count;
+    (0..column_count)
+        .map(|idx| base + usize::from(idx < remainder))
+        .collect()
+}
+
+/// Greedily put each section into the currently shortest column. Sections
+/// remain ordered within each column, while stacked layouts stay compact.
+fn balanced_help_columns(section_heights: &[usize], column_count: usize) -> Vec<Vec<usize>> {
+    if section_heights.is_empty() || column_count == 0 {
+        return Vec::new();
+    }
+    let column_count = column_count.min(section_heights.len());
+    let mut columns = vec![Vec::new(); column_count];
+    let mut heights = vec![0usize; column_count];
+
+    for (section_idx, &height) in section_heights.iter().enumerate() {
+        let column_idx = heights
+            .iter()
+            .enumerate()
+            .min_by_key(|(idx, height)| (**height, *idx))
+            .map(|(idx, _)| idx)
+            .unwrap_or(0);
+        if !columns[column_idx].is_empty() {
+            heights[column_idx] += 1;
+        }
+        columns[column_idx].push(section_idx);
+        heights[column_idx] += height;
+    }
+    columns
+}
+
+/// Format one help item as two styled parts whose concatenation occupies
+/// exactly `column_width` display cells, including Unicode-wide text and very
+/// narrow fallback layouts.
+fn help_item_parts(
+    prefix: &str,
+    key: &str,
+    description: &str,
+    key_width: usize,
+    column_width: usize,
+) -> (String, String) {
+    use unicode_width::UnicodeWidthStr;
+
+    let prefix_width = UnicodeWidthStr::width(prefix).min(column_width);
+    let mut key_part = pad_to_width(prefix, prefix_width);
+    let remaining = column_width.saturating_sub(prefix_width);
+    let key_area_width = (key_width + 1).min(remaining);
+    if key_area_width > 0 {
+        key_part.push_str(&pad_to_width(key, key_area_width.saturating_sub(1)));
+        key_part.push(' ');
+    }
+
+    let used = UnicodeWidthStr::width(key_part.as_str()).min(column_width);
+    let description_area_width = column_width.saturating_sub(used);
+    let description_part = if description_area_width == 0 {
+        String::new()
+    } else {
+        format!(
+            "{} ",
+            pad_to_width(description, description_area_width.saturating_sub(1))
+        )
+    };
+
+    (key_part, description_part)
+}
+
 pub(super) fn clear_overlay_area(f: &mut Frame, area: ratatui::layout::Rect) {
     let full = f.area();
     let extended = ratatui::layout::Rect {
@@ -4315,5 +4426,126 @@ fn vibrant(c: Color) -> Color {
         Color::Cyan => Color::LightCyan,
         Color::Magenta => Color::LightMagenta,
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod help_layout_tests {
+    use super::{
+        App, balanced_help_columns, help_column_count, help_column_widths, help_item_parts,
+        help_sheet_width,
+    };
+    use crate::{config::TuiConfig, pikpak::PikPak};
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use ratatui::{Terminal, backend::TestBackend};
+    use unicode_width::UnicodeWidthStr;
+
+    fn rendered_help(width: u16, height: u16) -> String {
+        let mut app = App::new_login(PikPak::new().unwrap(), None, TuiConfig::default());
+        app.show_help_sheet = true;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.draw_help_sheet(frame)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    #[test]
+    fn help_sheet_never_exceeds_a_narrow_terminal() {
+        for terminal_width in [0, 1, 20, 40, 44, 100] {
+            assert!(help_sheet_width(terminal_width) <= terminal_width);
+        }
+        assert_eq!(help_sheet_width(40), 40);
+        assert_eq!(help_sheet_width(100), 92);
+    }
+
+    #[test]
+    fn narrow_help_uses_fewer_columns_before_descriptions_collapse() {
+        assert_eq!(help_column_count(90, 3, 8), 3);
+        assert_eq!(help_column_count(38, 3, 8), 2);
+        assert_eq!(help_column_count(30, 3, 8), 2);
+        assert_eq!(help_column_count(17, 3, 8), 1);
+    }
+
+    #[test]
+    fn help_columns_use_every_available_display_cell() {
+        let widths = help_column_widths(89, 3);
+        assert_eq!(widths.iter().sum::<usize>(), 89);
+        assert!(widths.iter().max().unwrap() - widths.iter().min().unwrap() <= 1);
+    }
+
+    #[test]
+    fn unicode_help_item_is_exactly_one_column_wide() {
+        let (key, desc) = help_item_parts(" ", "快捷键", "移动到父目录", 8, 20);
+        assert_eq!(UnicodeWidthStr::width(format!("{key}{desc}").as_str()), 20);
+
+        let (key, desc) = help_item_parts(" ", "快捷键", "移动", 8, 6);
+        assert_eq!(UnicodeWidthStr::width(format!("{key}{desc}").as_str()), 6);
+    }
+
+    #[test]
+    fn stacked_sections_are_assigned_to_the_shortest_column() {
+        assert_eq!(
+            balanced_help_columns(&[15, 9, 11], 2),
+            vec![vec![0], vec![1, 2]]
+        );
+    }
+
+    #[test]
+    fn short_narrow_help_keeps_the_close_hint_visible() {
+        let rendered = rendered_help(20, 8);
+
+        assert!(
+            rendered.contains("close"),
+            "close hint was clipped:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn short_help_can_scroll_to_the_last_action() {
+        let mut app = App::new_login(PikPak::new().unwrap(), None, TuiConfig::default());
+        app.show_help_sheet = true;
+        let backend = TestBackend::new(20, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|frame| app.draw_help_sheet(frame)).unwrap();
+        assert!(app.help_scroll_max.get() > 0);
+        app.handle_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+        terminal.draw(|frame| app.draw_help_sheet(frame)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains("Quit"),
+            "last action was unreachable:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("close"),
+            "close hint disappeared:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn scroll_key_closes_help_when_the_sheet_does_not_need_scrolling() {
+        let mut app = App::new_login(PikPak::new().unwrap(), None, TuiConfig::default());
+        app.show_help_sheet = true;
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| app.draw_help_sheet(frame)).unwrap();
+        assert_eq!(app.help_scroll_max.get(), 0);
+
+        app.handle_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+
+        assert!(!app.show_help_sheet);
     }
 }

--- a/src/tui/handler.rs
+++ b/src/tui/handler.rs
@@ -12,8 +12,8 @@ use super::completion::PathInput;
 use super::download::{DownloadTask, TaskStatus};
 use super::local_completion::LocalPathInput;
 use super::{
-    App, InputMode, LoginField, OpResult, PickerState, PlayOption, PreviewState, handle_text_input,
-    widgets,
+    App, AsyncRequestKind, InputMode, LoginField, OpResult, PickerState, PlayOption, PreviewState,
+    handle_text_input, widgets,
 };
 
 /// Index of the last selectable Settings row. MUST match the item layout in
@@ -50,8 +50,34 @@ enum PathInputContext {
 impl App {
     pub(super) fn handle_key(&mut self, code: KeyCode, modifiers: KeyModifiers) -> Result<bool> {
         if self.show_help_sheet {
-            self.show_help_sheet = false;
+            let can_scroll = self.help_scroll_max.get() > 0;
+            match code {
+                KeyCode::Down | KeyCode::Char('j') if can_scroll => {
+                    self.help_scroll = (self.help_scroll + 1).min(self.help_scroll_max.get());
+                }
+                KeyCode::Up | KeyCode::Char('k') if can_scroll => {
+                    self.help_scroll = self.help_scroll.saturating_sub(1);
+                }
+                KeyCode::PageDown if can_scroll => {
+                    self.help_scroll = (self.help_scroll + 5).min(self.help_scroll_max.get());
+                }
+                KeyCode::PageUp if can_scroll => {
+                    self.help_scroll = self.help_scroll.saturating_sub(5);
+                }
+                KeyCode::Home if can_scroll => self.help_scroll = 0,
+                KeyCode::End if can_scroll => self.help_scroll = self.help_scroll_max.get(),
+                _ => {
+                    self.show_help_sheet = false;
+                    self.help_scroll = 0;
+                }
+            }
             return Ok(false);
+        }
+
+        // A pending play/goto response is only allowed to open its modal while
+        // the user has not performed another action in the meantime.
+        if !matches!(&self.input, InputMode::InfoLoading) {
+            self.invalidate_modal_request();
         }
 
         if code == KeyCode::Char('c') && modifiers.contains(KeyModifiers::CONTROL) {
@@ -205,10 +231,13 @@ impl App {
                         let q = query.trim().to_string();
                         if !q.is_empty() {
                             self.loading = true;
+                            let request =
+                                self.begin_modal_request(AsyncRequestKind::GotoPath, q.clone());
                             let client = Arc::clone(&self.client);
                             let tx = self.result_tx.clone();
                             std::thread::spawn(move || {
-                                let _ = tx.send(OpResult::GotoPath(client.resolve_path_nav(&q)));
+                                let _ = tx
+                                    .send(OpResult::GotoPath(request, client.resolve_path_nav(&q)));
                             });
                         }
                     }
@@ -478,6 +507,7 @@ impl App {
             }
             InputMode::InfoLoading => {
                 if code == KeyCode::Esc {
+                    self.invalidate_modal_request();
                     if !self.trash_entries.is_empty() {
                         self.input = InputMode::TrashView {
                             entries: std::mem::take(&mut self.trash_entries),
@@ -688,17 +718,15 @@ impl App {
                         self.clear_preview();
 
                         if let Some(children) = cached_children {
+                            self.invalidate_main_listing();
+                            self.finish_loading();
                             self.entries = children;
                             self.push_log(format!("Refreshed {}", self.current_path_display()));
                             self.on_cursor_move();
                         } else {
                             self.loading = true;
-                            let client = Arc::clone(&self.client);
-                            let tx = self.result_tx.clone();
                             let fid = self.current_folder_id.clone();
-                            std::thread::spawn(move || {
-                                let _ = tx.send(OpResult::Ls(client.ls(&fid)));
-                            });
+                            self.request_main_listing(fid);
                         }
                     } else if entry.kind == EntryKind::File
                         && theme::categorize(&entry) == theme::FileCategory::Video
@@ -707,8 +735,9 @@ impl App {
                         let client = Arc::clone(&self.client);
                         let tx = self.result_tx.clone();
                         let eid = entry.id.clone();
+                        let request = self.begin_modal_request(AsyncRequestKind::Play, eid.clone());
                         std::thread::spawn(move || {
-                            let _ = tx.send(OpResult::PlayInfo(client.file_info(&eid)));
+                            let _ = tx.send(OpResult::PlayInfo(request, client.file_info(&eid)));
                         });
                     }
                 }
@@ -716,6 +745,8 @@ impl App {
             KeyCode::Backspace => {
                 if let Some((parent_id, _)) = self.breadcrumb.pop() {
                     let leaving_id = std::mem::replace(&mut self.current_folder_id, parent_id);
+                    self.invalidate_main_listing();
+                    self.finish_loading();
                     let old_entries = std::mem::replace(
                         &mut self.entries,
                         std::mem::take(&mut self.parent_entries),
@@ -784,6 +815,7 @@ impl App {
             }
             KeyCode::Char('h') => {
                 self.show_help_sheet = true;
+                self.help_scroll = 0;
             }
             KeyCode::Char('a') => {
                 if let Some(entry) = self.current_entry().cloned() {
@@ -874,6 +906,8 @@ impl App {
                     let client = Arc::clone(&self.client);
                     let tx = self.result_tx.clone();
                     let eid = entry.id.clone();
+                    let request =
+                        self.begin_modal_request(AsyncRequestKind::PlayPicker, eid.clone());
                     std::thread::spawn(move || {
                         let result = client.file_info(&eid);
                         let _ = tx.send(match result {
@@ -921,9 +955,9 @@ impl App {
                                         });
                                     }
                                 }
-                                OpResult::PlayPickerInfo(Ok((info, options)))
+                                OpResult::PlayPickerInfo(request, Ok((info, options)))
                             }
-                            Err(e) => OpResult::PlayPickerInfo(Err(e)),
+                            Err(e) => OpResult::PlayPickerInfo(request, Err(e)),
                         });
                     });
                 }
@@ -939,10 +973,12 @@ impl App {
                         let client = Arc::clone(&self.client);
                         let tx = self.result_tx.clone();
                         let eid = entry.id.clone();
+                        let request =
+                            self.begin_modal_request(AsyncRequestKind::FilePreview, eid.clone());
                         let max_bytes = self.config.preview_max_size;
                         std::thread::spawn(move || {
                             let _ = tx.send(OpResult::PreviewText(
-                                eid.clone(),
+                                request,
                                 client.fetch_text_preview(&eid, max_bytes),
                             ));
                         });
@@ -1011,11 +1047,12 @@ impl App {
         match code {
             KeyCode::Esc => {
                 if !input.candidates.is_empty() {
-                    input.candidates.clear();
-                    input.candidate_idx = None;
-                    input.completion_base.clear();
+                    input.clear_completion();
                     PathInputKeyResult::Updated
                 } else {
+                    // Closing the dialog also invalidates any in-flight
+                    // completion result without requiring a second Esc.
+                    input.pending_request_id = None;
                     PathInputKeyResult::Cancelled
                 }
             }
@@ -1039,16 +1076,12 @@ impl App {
             }
             KeyCode::Backspace => {
                 input.value.pop();
-                input.candidates.clear();
-                input.candidate_idx = None;
-                input.completion_base.clear();
+                input.clear_completion();
                 PathInputKeyResult::Updated
             }
             KeyCode::Char(c) => {
                 input.value.push(c);
-                input.candidates.clear();
-                input.candidate_idx = None;
-                input.completion_base.clear();
+                input.clear_completion();
                 PathInputKeyResult::Updated
             }
             _ => PathInputKeyResult::Updated,
@@ -1129,9 +1162,10 @@ impl App {
     fn build_picker_state(&mut self) -> Option<PickerState> {
         let folder_id = self.current_folder_id.clone();
         let breadcrumb = self.breadcrumb.clone();
-        self.spawn_picker_ls(folder_id.clone());
+        let listing_request_id = self.spawn_picker_ls(folder_id.clone());
         Some(PickerState {
             folder_id,
+            listing_request_id,
             breadcrumb,
             entries: Vec::new(),
             selected: 0,
@@ -1139,12 +1173,18 @@ impl App {
         })
     }
 
-    fn spawn_picker_ls(&self, folder_id: String) {
+    fn spawn_picker_ls(&mut self, folder_id: String) -> u64 {
+        let request_id = self.next_async_request_id();
         let client = Arc::clone(&self.client);
         let tx = self.result_tx.clone();
         std::thread::spawn(move || {
-            let _ = tx.send(OpResult::PickerLs(folder_id.clone(), client.ls(&folder_id)));
+            let _ = tx.send(OpResult::PickerLs(
+                request_id,
+                folder_id.clone(),
+                client.ls(&folder_id),
+            ));
         });
+        request_id
     }
 
     fn init_picker(&mut self, source: Entry, is_move: bool) {
@@ -1191,7 +1231,7 @@ impl App {
                     picker.selected = 0;
                     picker.loading = true;
                     picker.entries.clear();
-                    self.spawn_picker_ls(picker.folder_id.clone());
+                    picker.listing_request_id = self.spawn_picker_ls(picker.folder_id.clone());
                 }
                 PickerKeyResult::Navigated
             }
@@ -1201,7 +1241,7 @@ impl App {
                     picker.selected = 0;
                     picker.loading = true;
                     picker.entries.clear();
-                    self.spawn_picker_ls(picker.folder_id.clone());
+                    picker.listing_request_id = self.spawn_picker_ls(picker.folder_id.clone());
                 }
                 PickerKeyResult::Navigated
             }
@@ -1262,6 +1302,7 @@ impl App {
             }
             PickerKeyResult::ShowHelp => {
                 self.show_help_sheet = true;
+                self.help_scroll = 0;
                 match &context {
                     PathInputContext::SingleItem { source } => {
                         self.restore_picker(source.clone(), picker, is_move)
@@ -1983,21 +2024,7 @@ impl App {
         // (different folders, or duplicates within one), and concurrent
         // workers writing one path interleave chunks into a corrupt file.
         // Names already queued for this directory count as taken too.
-        let mut taken: std::collections::HashSet<String> = self
-            .download_state
-            .tasks
-            .iter()
-            .filter(|t| t.dest_path.parent() == Some(dest.as_path()))
-            .filter_map(|t| {
-                t.dest_path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().into_owned())
-            })
-            .flat_map(|n| {
-                let sidecar = format!("{n}.part");
-                [n, sidecar]
-            })
-            .collect();
+        let mut taken = self.download_state.reserved_names_in(dest.as_path());
         for item in cart_items {
             // Sanitized: the name is server data and must not escape dest.
             let local_name = crate::pikpak::unique_local_name(
@@ -2115,25 +2142,10 @@ impl App {
             }
             KeyCode::Char('x') => {
                 let sel = self.download_state.selected;
-                let cancel_info = self.download_state.tasks.get(sel).and_then(|t| {
-                    matches!(
-                        t.status,
-                        TaskStatus::Downloading | TaskStatus::Paused | TaskStatus::Pending
-                    )
-                    .then(|| (t.id, t.name.clone(), Arc::clone(&t.cancel_flag)))
-                });
-                if let Some((id, name, cancel_flag)) = cancel_info {
-                    // Worker stops on cancel_flag without a Done/Failed message,
-                    // so drop its active_ids entry here.
-                    cancel_flag.store(true, Ordering::Relaxed);
-                    self.download_state.active_ids.remove(&id);
-                    self.download_state.tasks.remove(sel);
-                    if self.download_state.selected >= self.download_state.tasks.len()
-                        && self.download_state.selected > 0
-                    {
-                        self.download_state.selected -= 1;
-                    }
+                if let Some(name) = self.download_state.cancel_task(sel) {
                     self.push_log(format!("Cancelled '{}'", name));
+                    // If it had no worker (plain Pending), a slot is available
+                    // now. Otherwise active_ids retains the slot until Stopped.
                     self.download_state.start_next(&self.client);
                 }
                 self.input = InputMode::DownloadView;
@@ -2250,6 +2262,7 @@ impl App {
         self.input = InputMode::InfoLoading;
         self.loading = true;
         self.loading_label = Some("Loading offline tasks...".into());
+        let request = self.begin_modal_request(AsyncRequestKind::OfflineTasks, "offline-tasks");
         let client = Arc::clone(&self.client);
         let tx = self.result_tx.clone();
         std::thread::spawn(move || {
@@ -2260,7 +2273,7 @@ impl App {
                 "PHASE_TYPE_ERROR",
             ];
             let result = client.offline_list(50, phases).map(|r| r.tasks);
-            let _ = tx.send(OpResult::OfflineTasks(result));
+            let _ = tx.send(OpResult::OfflineTasks(request, result));
         });
     }
 
@@ -2530,13 +2543,22 @@ impl App {
                     };
                     let thumb_url = info.thumbnail_link.clone().filter(|u| !u.is_empty());
                     let has_thumbnail = thumb_url.is_some();
+                    let target_id = info.id.clone().unwrap_or_default();
+                    let request =
+                        self.begin_modal_request(AsyncRequestKind::Info, target_id.clone());
                     self.input = InputMode::InfoView {
+                        request_id: request.id,
+                        target_id,
                         info,
                         image: None,
                         has_thumbnail,
                     };
                     if let Some(url) = thumb_url {
-                        self.spawn_thumbnail_fetch(url, super::OpResult::InfoThumbnail);
+                        self.spawn_thumbnail_fetch(url, move |result| {
+                            super::OpResult::InfoThumbnail(request, result)
+                        });
+                    } else {
+                        self.modal_request = None;
                     }
                 } else {
                     self.input = InputMode::TrashView {
@@ -2579,12 +2601,17 @@ impl App {
         self.input = InputMode::InfoLoading;
         self.loading = true;
         self.loading_label = Some("Loading file info...".into());
+        let request = self.begin_modal_request(AsyncRequestKind::Info, entry.id.clone());
         let client = Arc::clone(&self.client);
         let tx = self.result_tx.clone();
         let eid = entry.id.clone();
         let thumb_fallback = entry.thumbnail_link.clone();
         std::thread::spawn(move || {
-            let _ = tx.send(OpResult::Info(client.file_info(&eid), thumb_fallback));
+            let _ = tx.send(OpResult::Info(
+                request,
+                client.file_info(&eid),
+                thumb_fallback,
+            ));
         });
     }
 
@@ -2594,11 +2621,12 @@ impl App {
         self.loading_label = Some("Loading folder...".into());
         self.preview_target_id = Some(entry.id.clone());
         self.preview_target_name = Some(entry.name.clone());
+        let request = self.begin_modal_request(AsyncRequestKind::FolderPreview, entry.id.clone());
         let client = Arc::clone(&self.client);
         let tx = self.result_tx.clone();
         let eid = entry.id.clone();
         std::thread::spawn(move || {
-            let _ = tx.send(OpResult::PreviewLs(eid.clone(), client.ls(&eid)));
+            let _ = tx.send(OpResult::PreviewLs(request, client.ls(&eid)));
         });
     }
 
@@ -2637,6 +2665,25 @@ impl App {
     }
 
     pub(super) fn handle_mouse(&mut self, mouse: MouseEvent) {
+        if self.show_help_sheet {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    self.help_scroll = self.help_scroll.saturating_sub(3);
+                }
+                MouseEventKind::ScrollDown => {
+                    self.help_scroll = (self.help_scroll + 3).min(self.help_scroll_max.get());
+                }
+                MouseEventKind::Down(_) => {
+                    self.show_help_sheet = false;
+                    self.help_scroll = 0;
+                }
+                _ => {}
+            }
+            return;
+        }
+        if !matches!(&self.input, InputMode::InfoLoading) {
+            self.invalidate_modal_request();
+        }
         match mouse.kind {
             MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
                 let up = matches!(mouse.kind, MouseEventKind::ScrollUp);
@@ -2779,6 +2826,7 @@ impl App {
         // must close it — not land on whatever pane sits underneath.
         if self.show_help_sheet {
             self.show_help_sheet = false;
+            self.help_scroll = 0;
             return;
         }
         // The logs overlay floats above a pane; don't click through it.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -100,24 +100,45 @@ pub(crate) struct PlayOption {
     pub available: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AsyncRequestKind {
+    Info,
+    FolderPreview,
+    FilePreview,
+    OfflineTasks,
+    Play,
+    PlayPicker,
+    GotoPath,
+    ParentListing,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct AsyncRequest {
+    id: u64,
+    kind: AsyncRequestKind,
+    target: String,
+}
+
 enum OpResult {
-    Ls(Result<Vec<Entry>>),
+    /// Main-pane folder listing. Folder and request ids prevent a delayed
+    /// reply from replacing a newer listing, including A -> B -> A navigation.
+    Ls(u64, String, Result<Vec<Entry>>),
     Ok(String),
     Err(String),
-    Info(Result<FileInfoResponse>, Option<String>),
-    ParentLs(String, Result<Vec<Entry>>),
-    PreviewLs(String, Result<Vec<Entry>>),
-    PreviewInfo(String, Result<FileInfoResponse>),
-    PreviewText(String, Result<(String, String, u64, bool)>),
-    PreviewThumbnail(String, Result<image::DynamicImage>),
-    OfflineTasks(Result<Vec<crate::pikpak::OfflineTask>>),
-    PlayInfo(Result<FileInfoResponse>),
-    PlayPickerInfo(Result<(FileInfoResponse, Vec<PlayOption>)>),
+    Info(AsyncRequest, Result<FileInfoResponse>, Option<String>),
+    ParentLs(AsyncRequest, Result<Vec<Entry>>),
+    PreviewLs(AsyncRequest, Result<Vec<Entry>>),
+    PreviewInfo(AsyncRequest, Result<FileInfoResponse>),
+    PreviewText(AsyncRequest, Result<(String, String, u64, bool)>),
+    PreviewThumbnail(AsyncRequest, Result<image::DynamicImage>),
+    OfflineTasks(AsyncRequest, Result<Vec<crate::pikpak::OfflineTask>>),
+    PlayInfo(AsyncRequest, Result<FileInfoResponse>),
+    PlayPickerInfo(AsyncRequest, Result<(FileInfoResponse, Vec<PlayOption>)>),
     TrashList(Result<Vec<Entry>>),
     TrashOp(String),
     OfflineOp(String),
-    InfoThumbnail(Result<image::DynamicImage>),
-    GotoPath(Result<(String, Vec<(String, String)>)>),
+    InfoThumbnail(AsyncRequest, Result<image::DynamicImage>),
+    GotoPath(AsyncRequest, Result<(String, Vec<(String, String)>)>),
     Quota(Result<crate::pikpak::QuotaInfo>),
     Upload(Result<String>),
     ShareCreated {
@@ -127,13 +148,15 @@ enum OpResult {
     },
     MyShares(Result<Vec<crate::pikpak::MyShare>>),
     UpdateAvailable(Option<String>),
-    /// Folder listing for the move/copy picker; the id guards against a reply
-    /// landing after the user already navigated elsewhere.
-    PickerLs(String, Result<Vec<Entry>>),
+    /// Folder listing for the move/copy picker; request and folder ids guard
+    /// against replies from both older navigation and cancelled dialogs.
+    PickerLs(u64, String, Result<Vec<Entry>>),
     /// Tab-completion candidates computed off-thread; `value` is the input
     /// text they were computed for.
     PathCandidates {
+        request_id: u64,
         value: String,
+        folder_context: String,
         parent: String,
         matches: Vec<String>,
     },
@@ -147,6 +170,7 @@ enum OpResult {
 #[derive(Default)]
 struct PickerState {
     folder_id: String,
+    listing_request_id: u64,
     breadcrumb: Vec<(String, String)>,
     entries: Vec<Entry>,
     selected: usize,
@@ -218,6 +242,8 @@ enum InputMode {
     },
     InfoLoading,
     InfoView {
+        request_id: u64,
+        target_id: String,
         info: FileInfoResponse,
         image: Option<image::DynamicImage>,
         has_thumbnail: bool,
@@ -289,6 +315,12 @@ struct App {
     client: Arc<PikPak>,
     config: TuiConfig,
     current_folder_id: String,
+    main_listing_request_id: u64,
+    async_request_generation: u64,
+    modal_request: Option<AsyncRequest>,
+    preview_request: Option<AsyncRequest>,
+    parent_listing_request: Option<AsyncRequest>,
+    path_completion_in_flight: Option<u64>,
     breadcrumb: Vec<(String, String)>,
     entries: Vec<Entry>,
     selected: usize,
@@ -300,6 +332,8 @@ struct App {
     spinner_idx: usize,
     last_spinner: Instant,
     show_help_sheet: bool,
+    help_scroll: usize,
+    help_scroll_max: Cell<usize>,
     result_rx: Receiver<OpResult>,
     result_tx: Sender<OpResult>,
     parent_entries: Vec<Entry>,
@@ -352,6 +386,12 @@ impl App {
             client: Arc::new(client),
             config,
             current_folder_id: String::new(),
+            main_listing_request_id: 0,
+            async_request_generation: 0,
+            modal_request: None,
+            preview_request: None,
+            parent_listing_request: None,
+            path_completion_in_flight: None,
             breadcrumb: Vec::new(),
             entries: Vec::new(),
             selected: 0,
@@ -363,6 +403,8 @@ impl App {
             spinner_idx: 0,
             last_spinner: Instant::now(),
             show_help_sheet: false,
+            help_scroll: 0,
+            help_scroll_max: Cell::new(0),
             result_rx: rx,
             result_tx: tx,
             parent_entries: Vec::new(),
@@ -432,6 +474,12 @@ impl App {
             client: Arc::new(client),
             config,
             current_folder_id: String::new(),
+            main_listing_request_id: 0,
+            async_request_generation: 0,
+            modal_request: None,
+            preview_request: None,
+            parent_listing_request: None,
+            path_completion_in_flight: None,
             breadcrumb: Vec::new(),
             entries: Vec::new(),
             selected: 0,
@@ -443,6 +491,8 @@ impl App {
             spinner_idx: 0,
             last_spinner: Instant::now(),
             show_help_sheet: false,
+            help_scroll: 0,
+            help_scroll_max: Cell::new(0),
             result_rx: rx,
             result_tx: tx,
             parent_entries: Vec::new(),
@@ -558,7 +608,15 @@ impl App {
     fn poll_results(&mut self) {
         while let Ok(result) = self.result_rx.try_recv() {
             match result {
-                OpResult::Ls(Ok(mut entries)) => {
+                OpResult::Ls(request_id, requested_folder_id, Ok(mut entries)) => {
+                    if !folder_listing_matches(
+                        &self.current_folder_id,
+                        self.main_listing_request_id,
+                        requested_folder_id.as_str(),
+                        request_id,
+                    ) {
+                        continue;
+                    }
                     self.finish_loading();
                     crate::config::sort_entries(
                         &mut entries,
@@ -576,7 +634,15 @@ impl App {
                     self.push_log(format!("Refreshed {}", self.current_path_display()));
                     self.on_cursor_move();
                 }
-                OpResult::Ls(Err(e)) => {
+                OpResult::Ls(request_id, requested_folder_id, Err(e)) => {
+                    if !folder_listing_matches(
+                        &self.current_folder_id,
+                        self.main_listing_request_id,
+                        requested_folder_id.as_str(),
+                        request_id,
+                    ) {
+                        continue;
+                    }
                     self.finish_loading();
                     self.push_log(format!("Refresh failed: {e:#}"));
                 }
@@ -588,35 +654,52 @@ impl App {
                     self.push_log(msg);
                     self.finish_loading();
                 }
-                OpResult::Info(Ok(info), thumb_fallback) => {
+                OpResult::Info(request, Ok(info), thumb_fallback) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::InfoLoading)
+                    {
+                        continue;
+                    }
                     self.finish_loading();
-                    if matches!(self.input, InputMode::InfoLoading) {
-                        let thumb_url = info
-                            .thumbnail_link
-                            .clone()
-                            .filter(|u| !u.is_empty())
-                            .or_else(|| thumb_fallback.filter(|u| !u.is_empty()));
-                        let has_thumbnail = thumb_url.is_some();
-                        self.input = InputMode::InfoView {
-                            info,
-                            image: None,
-                            has_thumbnail,
-                        };
-                        if let Some(url) = thumb_url {
-                            self.spawn_thumbnail_fetch(url, OpResult::InfoThumbnail);
-                        }
+                    let thumb_url = info
+                        .thumbnail_link
+                        .clone()
+                        .filter(|u| !u.is_empty())
+                        .or_else(|| thumb_fallback.filter(|u| !u.is_empty()));
+                    let has_thumbnail = thumb_url.is_some();
+                    self.input = InputMode::InfoView {
+                        request_id: request.id,
+                        target_id: request.target.clone(),
+                        info,
+                        image: None,
+                        has_thumbnail,
+                    };
+                    if let Some(url) = thumb_url {
+                        let thumbnail_request = request.clone();
+                        self.spawn_thumbnail_fetch(url, move |result| {
+                            OpResult::InfoThumbnail(thumbnail_request, result)
+                        });
+                    } else {
+                        self.modal_request = None;
                     }
                 }
-                OpResult::Info(Err(e), _) => {
-                    self.finish_loading();
-                    if matches!(self.input, InputMode::InfoLoading) {
-                        self.input = InputMode::Normal;
+                OpResult::Info(request, Err(e), _) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::InfoLoading)
+                    {
+                        continue;
                     }
+                    self.modal_request = None;
+                    self.finish_loading();
+                    self.input = InputMode::Normal;
                     self.push_log(format!("File info failed: {e:#}"));
                 }
-                OpResult::ParentLs(pid, Ok(mut entries)) => {
+                OpResult::ParentLs(request, Ok(mut entries)) => {
                     let expected = self.breadcrumb.last().map(|(id, _)| id.as_str());
-                    if expected == Some(&pid) {
+                    if self.parent_listing_request.as_ref() == Some(&request)
+                        && expected == Some(request.target.as_str())
+                    {
+                        self.parent_listing_request = None;
                         crate::config::sort_entries(
                             &mut entries,
                             self.config.sort_field,
@@ -632,54 +715,84 @@ impl App {
                         }
                     }
                 }
-                OpResult::ParentLs(pid, Err(e)) => {
+                OpResult::ParentLs(request, Err(e)) => {
                     let expected = self.breadcrumb.last().map(|(id, _)| id.as_str());
-                    if expected == Some(&pid) {
+                    if self.parent_listing_request.as_ref() == Some(&request)
+                        && expected == Some(request.target.as_str())
+                    {
+                        self.parent_listing_request = None;
                         self.push_log(format!("Parent listing failed: {e:#}"));
                     }
                 }
-                OpResult::PreviewLs(id, Ok(mut children)) => {
+                OpResult::PreviewLs(request, Ok(mut children)) => {
+                    let is_modal = self.modal_request_matches(&request)
+                        && matches!(self.input, InputMode::InfoLoading);
+                    let is_preview = self.preview_request_matches(&request);
+                    if !is_modal && !is_preview {
+                        continue;
+                    }
                     crate::config::sort_entries(
                         &mut children,
                         self.config.sort_field,
                         self.config.sort_reverse,
                     );
-                    if matches!(self.input, InputMode::InfoLoading) {
+                    if is_modal {
+                        self.modal_request = None;
                         self.finish_loading();
                         let name = self.preview_target_name.take().unwrap_or_default();
                         self.preview_state = PreviewState::FolderListing(children.clone());
-                        self.preview_target_id = Some(id);
+                        self.preview_target_id = Some(request.target);
                         self.input = InputMode::InfoFolderView {
                             name,
                             entries: children,
                         };
-                    } else if self.preview_target_id.as_deref() == Some(&id) {
+                    } else {
+                        self.preview_request = None;
                         self.preview_state = PreviewState::FolderListing(children);
                     }
                 }
-                OpResult::PreviewLs(id, Err(e)) => {
-                    if matches!(self.input, InputMode::InfoLoading) {
+                OpResult::PreviewLs(request, Err(e)) => {
+                    let is_modal = self.modal_request_matches(&request)
+                        && matches!(self.input, InputMode::InfoLoading);
+                    let is_preview = self.preview_request_matches(&request);
+                    if !is_modal && !is_preview {
+                        continue;
+                    }
+                    if is_modal {
+                        self.modal_request = None;
                         self.finish_loading();
                         self.input = InputMode::Normal;
-                    } else if self.preview_target_id.as_deref() == Some(&id) {
+                    } else {
+                        self.preview_request = None;
                         self.preview_state = PreviewState::Empty;
                     }
                     self.push_log(format!("Folder listing failed: {e:#}"));
                 }
-                OpResult::PreviewInfo(id, Ok(info)) => {
-                    if self.preview_target_id.as_deref() == Some(&id) {
-                        self.preview_state = PreviewState::FileDetailedInfo(info);
+                OpResult::PreviewInfo(request, Ok(info)) => {
+                    if !self.preview_request_matches(&request) {
+                        continue;
                     }
+                    self.preview_request = None;
+                    self.preview_state = PreviewState::FileDetailedInfo(info);
                 }
-                OpResult::PreviewInfo(id, Err(e)) => {
-                    if self.preview_target_id.as_deref() == Some(&id) {
-                        self.preview_state = PreviewState::Empty;
+                OpResult::PreviewInfo(request, Err(e)) => {
+                    if !self.preview_request_matches(&request) {
+                        continue;
                     }
+                    self.preview_request = None;
+                    self.preview_state = PreviewState::Empty;
                     self.push_log(format!("Preview info failed: {e:#}"));
                 }
-                OpResult::PreviewText(id, Ok((name, content, size, truncated))) => {
+                OpResult::PreviewText(request, Ok((name, content, size, truncated))) => {
+                    let is_modal = self.modal_request_matches(&request)
+                        && matches!(self.input, InputMode::InfoLoading);
+                    let is_preview = self.preview_request_matches(&request);
+                    if !is_modal && !is_preview {
+                        continue;
+                    }
                     let lines = highlight_content(&name, &content);
-                    if matches!(self.input, InputMode::InfoLoading) {
+                    if is_modal {
+                        self.modal_request = None;
                         self.finish_loading();
                         self.input = InputMode::TextPreviewView {
                             name: name.clone(),
@@ -692,8 +805,9 @@ impl App {
                             size,
                             truncated,
                         };
-                        self.preview_target_id = Some(id);
-                    } else if self.preview_target_id.as_deref() == Some(&id) {
+                        self.preview_target_id = Some(request.target);
+                    } else {
+                        self.preview_request = None;
                         self.preview_state = PreviewState::FileTextPreview {
                             name,
                             lines,
@@ -702,40 +816,66 @@ impl App {
                         };
                     }
                 }
-                OpResult::PreviewText(id, Err(e)) => {
-                    if matches!(self.input, InputMode::InfoLoading) {
+                OpResult::PreviewText(request, Err(e)) => {
+                    let is_modal = self.modal_request_matches(&request)
+                        && matches!(self.input, InputMode::InfoLoading);
+                    let is_preview = self.preview_request_matches(&request);
+                    if !is_modal && !is_preview {
+                        continue;
+                    }
+                    if is_modal {
+                        self.modal_request = None;
                         self.finish_loading();
                         self.input = InputMode::Normal;
-                    } else if self.preview_target_id.as_deref() == Some(&id) {
+                    } else {
+                        self.preview_request = None;
                         self.preview_state = PreviewState::FileBasicInfo;
                     }
                     self.push_log(format!("Text preview failed: {e:#}"));
                 }
-                OpResult::PreviewThumbnail(id, Ok(image)) => {
-                    if self.preview_target_id.as_deref() == Some(&id) {
-                        self.preview_state = PreviewState::ThumbnailImage { image };
+                OpResult::PreviewThumbnail(request, Ok(image)) => {
+                    if !self.preview_request_matches(&request) {
+                        continue;
                     }
+                    self.preview_request = None;
+                    self.preview_state = PreviewState::ThumbnailImage { image };
                 }
-                OpResult::PreviewThumbnail(id, Err(e)) => {
-                    if self.preview_target_id.as_deref() == Some(&id) {
-                        self.preview_state = PreviewState::FileBasicInfo;
+                OpResult::PreviewThumbnail(request, Err(e)) => {
+                    if !self.preview_request_matches(&request) {
+                        continue;
                     }
+                    self.preview_request = None;
+                    self.preview_state = PreviewState::FileBasicInfo;
                     self.push_log(format!("Thumbnail preview failed: {e:#}"));
                 }
-                OpResult::OfflineTasks(Ok(tasks)) => {
-                    self.finish_loading();
-                    if matches!(self.input, InputMode::InfoLoading) {
-                        self.input = InputMode::OfflineTasksView { tasks, selected: 0 };
+                OpResult::OfflineTasks(request, Ok(tasks)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::InfoLoading)
+                    {
+                        continue;
                     }
+                    self.modal_request = None;
+                    self.finish_loading();
+                    self.input = InputMode::OfflineTasksView { tasks, selected: 0 };
                 }
-                OpResult::OfflineTasks(Err(e)) => {
-                    self.finish_loading();
-                    if matches!(self.input, InputMode::InfoLoading) {
-                        self.input = InputMode::Normal;
+                OpResult::OfflineTasks(request, Err(e)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::InfoLoading)
+                    {
+                        continue;
                     }
+                    self.modal_request = None;
+                    self.finish_loading();
+                    self.input = InputMode::Normal;
                     self.push_log(format!("Failed to load offline tasks: {e:#}"));
                 }
-                OpResult::PlayInfo(Ok(info)) => {
+                OpResult::PlayInfo(request, Ok(info)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     let url = info
                         .web_content_link
@@ -755,11 +895,23 @@ impl App {
                         };
                     }
                 }
-                OpResult::PlayInfo(Err(e)) => {
+                OpResult::PlayInfo(request, Err(e)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     self.push_log(format!("Play info failed: {e:#}"));
                 }
-                OpResult::PlayPickerInfo(Ok((info, medias))) => {
+                OpResult::PlayPickerInfo(request, Ok((info, medias))) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     if medias.is_empty() {
                         self.push_log("No playback streams available".into());
@@ -772,7 +924,13 @@ impl App {
                         };
                     }
                 }
-                OpResult::PlayPickerInfo(Err(e)) => {
+                OpResult::PlayPickerInfo(request, Err(e)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     self.push_log(format!("Play picker info failed: {e:#}"));
                 }
@@ -812,15 +970,50 @@ impl App {
                     self.push_log(msg);
                     self.open_offline_tasks_view();
                 }
-                OpResult::InfoThumbnail(Ok(img)) => {
-                    if let InputMode::InfoView { ref mut image, .. } = self.input {
-                        *image = Some(img);
+                OpResult::InfoThumbnail(request, Ok(img)) => {
+                    if !self.modal_request_matches(&request) {
+                        continue;
                     }
+                    let InputMode::InfoView {
+                        request_id,
+                        target_id,
+                        image,
+                        ..
+                    } = &mut self.input
+                    else {
+                        continue;
+                    };
+                    if *request_id != request.id || target_id != &request.target {
+                        continue;
+                    }
+                    *image = Some(img);
+                    self.modal_request = None;
                 }
-                OpResult::InfoThumbnail(Err(e)) => {
+                OpResult::InfoThumbnail(request, Err(e)) => {
+                    if !self.modal_request_matches(&request) {
+                        continue;
+                    }
+                    let matches_view = matches!(
+                        &self.input,
+                        InputMode::InfoView {
+                            request_id,
+                            target_id,
+                            ..
+                        } if *request_id == request.id && target_id == &request.target
+                    );
+                    if !matches_view {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.push_log(format!("Info thumbnail failed: {e:#}"));
                 }
-                OpResult::GotoPath(Ok((folder_id, new_breadcrumb))) => {
+                OpResult::GotoPath(request, Ok((folder_id, new_breadcrumb))) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     self.breadcrumb = new_breadcrumb;
                     self.current_folder_id = folder_id.clone();
@@ -832,13 +1025,15 @@ impl App {
                     self.refresh_parent();
                     self.clear_preview();
                     self.loading = true;
-                    let client = Arc::clone(&self.client);
-                    let tx = self.result_tx.clone();
-                    std::thread::spawn(move || {
-                        let _ = tx.send(OpResult::Ls(client.ls(&folder_id)));
-                    });
+                    self.request_main_listing(folder_id);
                 }
-                OpResult::GotoPath(Err(e)) => {
+                OpResult::GotoPath(request, Err(e)) => {
+                    if !self.modal_request_matches(&request)
+                        || !matches!(self.input, InputMode::Normal)
+                    {
+                        continue;
+                    }
+                    self.modal_request = None;
                     self.finish_loading();
                     self.push_log(format!("Go to path failed: {e:#}"));
                 }
@@ -908,7 +1103,7 @@ impl App {
                     self.update_available = Some(version);
                 }
                 OpResult::UpdateAvailable(None) => {}
-                OpResult::PickerLs(folder_id, result) => {
+                OpResult::PickerLs(request_id, folder_id, result) => {
                     let picker = match &mut self.input {
                         InputMode::MovePicker { picker, .. }
                         | InputMode::CopyPicker { picker, .. }
@@ -919,6 +1114,7 @@ impl App {
                     let mut log = None;
                     if let Some(p) = picker
                         && p.folder_id == folder_id
+                        && p.listing_request_id == request_id
                     {
                         match result {
                             Ok(mut entries) => {
@@ -938,10 +1134,17 @@ impl App {
                     }
                 }
                 OpResult::PathCandidates {
+                    request_id,
                     value,
+                    folder_context,
                     parent,
                     matches,
                 } => {
+                    if self.path_completion_in_flight != Some(request_id) {
+                        continue;
+                    }
+                    self.path_completion_in_flight = None;
+                    let current_folder_id = self.current_folder_id.clone();
                     let input = match &mut self.input {
                         InputMode::MoveInput { input, .. }
                         | InputMode::CopyInput { input, .. }
@@ -949,9 +1152,18 @@ impl App {
                         | InputMode::CartCopyInput { input } => Some(input),
                         _ => None,
                     };
-                    // Only apply if the user hasn't typed since Tab was hit.
+                    // Request identity protects a newly opened dialog from an
+                    // old dialog's response; value and folder protect edits
+                    // and navigation within the same dialog.
                     if let Some(inp) = input
-                        && inp.value == value
+                        && completion::path_candidate_result_matches(
+                            inp,
+                            request_id,
+                            value.as_str(),
+                            current_folder_id.as_str(),
+                            folder_context.as_str(),
+                        )
+                        && !matches.is_empty()
                     {
                         completion::apply_path_candidates(inp, parent, matches);
                     }
@@ -1082,25 +1294,99 @@ impl App {
 
     fn refresh(&mut self) {
         self.loading = true;
-        let client = Arc::clone(&self.client);
-        let tx = self.result_tx.clone();
         let fid = self.current_folder_id.clone();
-        std::thread::spawn(move || {
-            let _ = tx.send(OpResult::Ls(client.ls(&fid)));
-        });
+        self.request_main_listing(fid);
         self.refresh_parent();
         self.fetch_quota();
     }
 
+    fn request_main_listing(&mut self, folder_id: String) {
+        self.invalidate_main_listing();
+        let request_id = self.main_listing_request_id;
+        let client = Arc::clone(&self.client);
+        let tx = self.result_tx.clone();
+        std::thread::spawn(move || {
+            let result = client.ls(&folder_id);
+            let _ = tx.send(OpResult::Ls(request_id, folder_id, result));
+        });
+    }
+
+    fn invalidate_main_listing(&mut self) {
+        self.main_listing_request_id = self.main_listing_request_id.wrapping_add(1);
+    }
+
+    fn next_async_request_id(&mut self) -> u64 {
+        self.async_request_generation = self.async_request_generation.wrapping_add(1);
+        self.async_request_generation
+    }
+
+    fn new_async_request(
+        &mut self,
+        kind: AsyncRequestKind,
+        target: impl Into<String>,
+    ) -> AsyncRequest {
+        AsyncRequest {
+            id: self.next_async_request_id(),
+            kind,
+            target: target.into(),
+        }
+    }
+
+    fn begin_modal_request(
+        &mut self,
+        kind: AsyncRequestKind,
+        target: impl Into<String>,
+    ) -> AsyncRequest {
+        let request = self.new_async_request(kind, target);
+        self.modal_request = Some(request.clone());
+        request
+    }
+
+    fn begin_preview_request(
+        &mut self,
+        kind: AsyncRequestKind,
+        target: impl Into<String>,
+    ) -> AsyncRequest {
+        let request = self.new_async_request(kind, target);
+        self.preview_request = Some(request.clone());
+        request
+    }
+
+    fn modal_request_matches(&self, request: &AsyncRequest) -> bool {
+        self.modal_request.as_ref() == Some(request)
+    }
+
+    fn preview_request_matches(&self, request: &AsyncRequest) -> bool {
+        self.preview_request.as_ref() == Some(request)
+            && self.preview_target_id.as_deref() == Some(request.target.as_str())
+    }
+
+    fn invalidate_modal_request(&mut self) {
+        let request_owned_loading = self.modal_request.as_ref().is_some_and(|request| {
+            matches!(
+                request.kind,
+                AsyncRequestKind::Play | AsyncRequestKind::PlayPicker | AsyncRequestKind::GotoPath
+            )
+        });
+        self.modal_request = None;
+        if request_owned_loading {
+            self.finish_loading();
+        }
+    }
+
     fn refresh_parent(&mut self) {
-        if let Some((parent_id, _)) = self.breadcrumb.last() {
+        if let Some(parent_id) = self.breadcrumb.last().map(|(id, _)| id.clone()) {
+            let request =
+                self.new_async_request(AsyncRequestKind::ParentListing, parent_id.clone());
+            self.parent_listing_request = Some(request.clone());
             let client = Arc::clone(&self.client);
             let tx = self.result_tx.clone();
-            let pid = parent_id.clone();
+            let pid = parent_id;
             std::thread::spawn(move || {
-                let _ = tx.send(OpResult::ParentLs(pid.clone(), client.ls(&pid)));
+                let _ = tx.send(OpResult::ParentLs(request, client.ls(&pid)));
             });
         } else {
+            self.parent_listing_request = None;
             self.parent_entries.clear();
             self.parent_selected = 0;
         }
@@ -1110,12 +1396,14 @@ impl App {
         self.preview_state = PreviewState::Empty;
         self.preview_target_id = None;
         self.preview_target_name = None;
+        self.preview_request = None;
         self.pending_preview_fetch = false;
         self.preview_scroll = 0;
     }
 
     fn on_cursor_move(&mut self) {
         self.preview_scroll = 0;
+        self.preview_request = None;
         if !self.config.show_preview {
             return;
         }
@@ -1162,31 +1450,39 @@ impl App {
         let eid = entry.id.clone();
         match entry.kind {
             EntryKind::Folder => {
+                let request =
+                    self.begin_preview_request(AsyncRequestKind::FolderPreview, eid.clone());
                 // Folders always show content listing, never thumbnails
                 std::thread::spawn(move || {
-                    let _ = tx.send(OpResult::PreviewLs(eid.clone(), client.ls(&eid)));
+                    let _ = tx.send(OpResult::PreviewLs(request, client.ls(&eid)));
                 });
             }
             EntryKind::File => {
                 if let Some(ref thumb_url) = entry.thumbnail_link
                     && !thumb_url.is_empty()
                 {
+                    let request =
+                        self.begin_preview_request(AsyncRequestKind::FilePreview, eid.clone());
                     self.spawn_thumbnail_fetch(thumb_url.clone(), move |r| {
-                        OpResult::PreviewThumbnail(eid.clone(), r)
+                        OpResult::PreviewThumbnail(request, r)
                     });
                     return;
                 }
                 if theme::is_text_previewable(&entry) {
+                    let request =
+                        self.begin_preview_request(AsyncRequestKind::FilePreview, eid.clone());
                     let max_bytes = self.config.preview_max_size;
                     std::thread::spawn(move || {
                         let _ = tx.send(OpResult::PreviewText(
-                            eid.clone(),
+                            request,
                             client.fetch_text_preview(&eid, max_bytes),
                         ));
                     });
                 } else {
+                    let request =
+                        self.begin_preview_request(AsyncRequestKind::FilePreview, eid.clone());
                     std::thread::spawn(move || {
-                        let _ = tx.send(OpResult::PreviewInfo(eid.clone(), client.file_info(&eid)));
+                        let _ = tx.send(OpResult::PreviewInfo(request, client.file_info(&eid)));
                     });
                 }
             }
@@ -1323,6 +1619,338 @@ fn truncate_name(name: &str, max_width: usize) -> String {
         }
         out.push_str("...");
         out
+    }
+}
+
+fn folder_listing_matches(
+    current_folder_id: &str,
+    current_request_id: u64,
+    requested_folder_id: &str,
+    request_id: u64,
+) -> bool {
+    current_folder_id == requested_folder_id && current_request_id == request_id
+}
+
+#[cfg(test)]
+mod folder_listing_result_tests {
+    use super::{
+        App, AsyncRequest, AsyncRequestKind, InputMode, OpResult, PreviewState,
+        folder_listing_matches,
+    };
+    use crate::config::TuiConfig;
+    use crate::pikpak::{Entry, EntryKind, FileInfoResponse, PikPak};
+    use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    fn test_app() -> App {
+        App::new_login(PikPak::new().unwrap(), None, TuiConfig::default())
+    }
+
+    fn info(id: &str, name: &str) -> FileInfoResponse {
+        FileInfoResponse {
+            id: Some(id.to_string()),
+            name: name.to_string(),
+            kind: Some("drive#file".to_string()),
+            size: None,
+            hash: None,
+            mime_type: None,
+            created_time: None,
+            modified_time: None,
+            web_content_link: Some("https://example.invalid/video".to_string()),
+            thumbnail_link: None,
+            links: None,
+            medias: None,
+        }
+    }
+
+    fn folder(id: &str, name: &str) -> Entry {
+        Entry {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: EntryKind::Folder,
+            size: 0,
+            created_time: String::new(),
+            modified_time: String::new(),
+            starred: false,
+            thumbnail_link: None,
+        }
+    }
+
+    fn request(id: u64, kind: AsyncRequestKind, target: &str) -> AsyncRequest {
+        AsyncRequest {
+            id,
+            kind,
+            target: target.to_string(),
+        }
+    }
+
+    #[test]
+    fn main_listing_result_is_bound_to_its_requested_folder() {
+        let result = OpResult::Ls(7, "folder-a".to_string(), Ok(Vec::new()));
+        let OpResult::Ls(request_id, requested_folder_id, _) = result else {
+            panic!("expected a main folder listing result");
+        };
+
+        assert!(folder_listing_matches(
+            "folder-a",
+            7,
+            requested_folder_id.as_str(),
+            request_id,
+        ));
+        assert!(!folder_listing_matches(
+            "folder-b",
+            7,
+            requested_folder_id.as_str(),
+            request_id,
+        ));
+    }
+
+    #[test]
+    fn older_listing_for_same_folder_cannot_replace_newer_listing() {
+        assert!(!folder_listing_matches("folder-a", 8, "folder-a", 7));
+        assert!(folder_listing_matches("folder-a", 8, "folder-a", 8));
+    }
+
+    #[test]
+    fn older_parent_listing_for_the_same_parent_cannot_replace_a_newer_one() {
+        let mut app = test_app();
+        app.breadcrumb = vec![("parent".to_string(), "child".to_string())];
+        let old_request = request(1, AsyncRequestKind::ParentListing, "parent");
+        let new_request = request(2, AsyncRequestKind::ParentListing, "parent");
+        app.parent_listing_request = Some(new_request.clone());
+        app.result_tx
+            .send(OpResult::ParentLs(
+                new_request,
+                Ok(vec![folder("new", "new")]),
+            ))
+            .unwrap();
+        app.result_tx
+            .send(OpResult::ParentLs(
+                old_request,
+                Ok(vec![folder("old", "old")]),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        assert_eq!(app.parent_entries[0].id, "new");
+    }
+
+    #[test]
+    fn older_picker_listing_for_same_folder_cannot_replace_newer_dialog_result() {
+        let mut app = test_app();
+        app.input = InputMode::CopyPicker {
+            source: folder("source", "source"),
+            picker: super::PickerState {
+                folder_id: "folder-a".to_string(),
+                listing_request_id: 2,
+                breadcrumb: Vec::new(),
+                entries: Vec::new(),
+                selected: 0,
+                loading: true,
+            },
+        };
+        // The current dialog's response lands first, then the older request
+        // from a cancelled dialog returns for the same folder.
+        app.result_tx
+            .send(OpResult::PickerLs(
+                2,
+                "folder-a".to_string(),
+                Ok(vec![folder("new", "new")]),
+            ))
+            .unwrap();
+        app.result_tx
+            .send(OpResult::PickerLs(
+                1,
+                "folder-a".to_string(),
+                Ok(vec![folder("old", "old")]),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        let InputMode::CopyPicker { picker, .. } = app.input else {
+            panic!("picker unexpectedly closed");
+        };
+        assert_eq!(picker.entries[0].id, "new");
+    }
+
+    #[test]
+    fn cached_child_navigation_finishes_the_invalidated_network_loading_state() {
+        let mut app = test_app();
+        app.input = InputMode::Normal;
+        app.entries = vec![folder("child", "child")];
+        app.selected = 0;
+        app.preview_target_id = Some("child".to_string());
+        app.preview_state = PreviewState::FolderListing(Vec::new());
+        app.loading = true;
+
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+
+        assert!(!app.loading);
+    }
+
+    #[test]
+    fn cached_parent_navigation_finishes_the_invalidated_network_loading_state() {
+        let mut app = test_app();
+        app.input = InputMode::Normal;
+        app.current_folder_id = "child".to_string();
+        app.breadcrumb = vec![("parent".to_string(), "child".to_string())];
+        app.parent_entries = vec![folder("sibling", "sibling")];
+        app.loading = true;
+
+        app.handle_key(KeyCode::Backspace, KeyModifiers::NONE)
+            .unwrap();
+
+        assert!(!app.loading);
+    }
+
+    #[test]
+    fn stale_info_result_cannot_replace_a_newer_loading_target() {
+        let mut app = test_app();
+        app.input = InputMode::InfoLoading;
+        app.modal_request = Some(request(2, AsyncRequestKind::Info, "new-target"));
+        app.result_tx
+            .send(OpResult::Info(
+                request(1, AsyncRequestKind::Info, "old-target"),
+                Ok(info("old-target", "old")),
+                None,
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        assert!(matches!(app.input, InputMode::InfoLoading));
+    }
+
+    #[test]
+    fn stale_folder_preview_cannot_replace_a_newer_loading_target() {
+        let mut app = test_app();
+        app.input = InputMode::InfoLoading;
+        app.preview_target_id = Some("new-target".to_string());
+        app.preview_target_name = Some("new".to_string());
+        app.modal_request = Some(request(2, AsyncRequestKind::FolderPreview, "new-target"));
+        app.result_tx
+            .send(OpResult::PreviewLs(
+                request(1, AsyncRequestKind::FolderPreview, "old-target"),
+                Ok(Vec::new()),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        assert!(matches!(app.input, InputMode::InfoLoading));
+    }
+
+    #[test]
+    fn stale_thumbnail_cannot_land_on_a_different_info_view() {
+        let mut app = test_app();
+        app.modal_request = Some(request(2, AsyncRequestKind::Info, "new-target"));
+        app.input = InputMode::InfoView {
+            request_id: 2,
+            target_id: "new-target".to_string(),
+            info: info("new-target", "new"),
+            image: None,
+            has_thumbnail: true,
+        };
+        app.result_tx
+            .send(OpResult::InfoThumbnail(
+                request(1, AsyncRequestKind::Info, "old-target"),
+                Ok(image::DynamicImage::new_rgb8(1, 1)),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        let InputMode::InfoView { image, .. } = app.input else {
+            panic!("info view was unexpectedly replaced");
+        };
+        assert!(image.is_none());
+    }
+
+    #[test]
+    fn delayed_play_result_cannot_replace_a_later_modal() {
+        let mut app = test_app();
+        app.input = InputMode::Settings {
+            selected: 0,
+            editing: false,
+            draft: TuiConfig::default(),
+            modified: false,
+        };
+        app.modal_request = Some(request(1, AsyncRequestKind::Play, "old-target"));
+        app.result_tx
+            .send(OpResult::PlayInfo(
+                request(1, AsyncRequestKind::Play, "old-target"),
+                Ok(info("old-target", "old")),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        assert!(matches!(app.input, InputMode::Settings { .. }));
+    }
+
+    #[test]
+    fn keyboard_invalidation_of_pending_interactive_request_finishes_its_loading_state() {
+        for kind in [
+            AsyncRequestKind::Play,
+            AsyncRequestKind::PlayPicker,
+            AsyncRequestKind::GotoPath,
+        ] {
+            let mut app = test_app();
+            app.input = InputMode::Normal;
+            app.loading = true;
+            app.modal_request = Some(request(1, kind, "target"));
+
+            app.handle_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+
+            assert!(app.modal_request.is_none(), "{kind:?}");
+            assert!(!app.loading, "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn mouse_invalidation_of_pending_play_finishes_its_loading_state() {
+        let mut app = test_app();
+        app.input = InputMode::Normal;
+        app.loading = true;
+        app.modal_request = Some(request(1, AsyncRequestKind::Play, "video"));
+
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        });
+
+        assert!(app.modal_request.is_none());
+        assert!(!app.loading);
+    }
+
+    #[test]
+    fn delayed_goto_result_cannot_navigate_after_a_later_modal_opened() {
+        let mut app = test_app();
+        app.current_folder_id = "before".to_string();
+        app.input = InputMode::Settings {
+            selected: 0,
+            editing: false,
+            draft: TuiConfig::default(),
+            modified: false,
+        };
+        app.modal_request = Some(request(1, AsyncRequestKind::GotoPath, "/after"));
+        app.result_tx
+            .send(OpResult::GotoPath(
+                request(1, AsyncRequestKind::GotoPath, "/after"),
+                Ok((
+                    "after".to_string(),
+                    vec![("".to_string(), "after".to_string())],
+                )),
+            ))
+            .unwrap();
+
+        app.poll_results();
+
+        assert_eq!(app.current_folder_id, "before");
+        assert!(matches!(app.input, InputMode::Settings { .. }));
     }
 }
 


### PR DESCRIPTION
## Summary

- make TUI listings, previews, pickers, modals, downloads, completion, and the help page robust against stale async results and narrow terminals
- protect download resume state, cancellation targets, upload boundaries, captcha refresh, session persistence, share pagination, and ambiguous remote paths
- harden release provenance checks, installer checksum handling, shell completions, and English/Chinese documentation

## Root cause

Several asynchronous operations were identified only by their result type or destination, allowing old work to affect newer UI state. Transfer sidecars and cancellation state also lacked complete ownership checks. Authentication/session updates, pagination, and release tooling relied on assumptions that were unsafe under concurrency, malformed responses, or partial publication.

## User impact

The changes prevent stale TUI navigation and modal updates, unsafe partial-download reuse, symlink traversal during upload, incorrect captcha replay, lost session fields, pagination loops, and accidental or incomplete releases. Completion output and documentation now match the current CLI.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` — 199 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo build --release --locked`
- `git diff --check`
- shell syntax, workflow YAML, docs config, package listing, release-binary help/version, and completion smoke tests
